### PR TITLE
Support multistage tests

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -31,7 +31,7 @@ run_tests <- function(ctx, tests, skip, run_only, test_suite) {
       if (skip_flag[[test_idx]]) {
         FALSE
       } else {
-        test_fun <- patch_test_fun(tests[[test_name]], paste0(test_context, ": ", test_name))
+        test_fun <- patch_test_fun(tests[[test_idx]], paste0(test_context, ": ", test_name))
 
         args <- list()
         if ("ctx" %in% names(formals(test_fun))) {

--- a/R/spec-result-send-query.R
+++ b/R/spec-result-send-query.R
@@ -67,11 +67,12 @@ spec_result_send_query <- list(
   send_query_stale_warning = function(ctx) {
     #' Failure to clear the result set leads to a warning
     #' when the connection is closed.
-    expect_warning(
-      with_connection(ctx = ctx, {
-        dbSendQuery(con, trivial_query())
-      })
-    )
+    con <- connect(ctx)
+    on.exit(dbDisconnect(con))
+    expect_warning(dbSendQuery(con, trivial_query()), NA)
+
+    on.exit(NULL)
+    expect_warning(dbDisconnect(con))
   },
 
   #'

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -63,11 +63,12 @@ spec_result_send_statement <- list(
   send_statement_stale_warning = function(ctx) {
     #' Failure to clear the result set leads to a warning
     #' when the connection is closed.
-    expect_warning(
-      with_connection(ctx = ctx, {
-        expect_warning(dbSendStatement(con, trivial_query()), NA)
-      })
-    )
+    con <- connect(ctx)
+    on.exit(dbDisconnect(con))
+    expect_warning(dbSendStatement(con, trivial_query()), NA)
+
+    on.exit(NULL)
+    expect_warning(dbDisconnect(con))
   },
 
   #' If the backend supports only one open result set per connection,

--- a/R/spec-sql-create-table.R
+++ b/R/spec-sql-create-table.R
@@ -113,55 +113,43 @@ spec_sql_create_table <- list(
   #'
   #' If the `temporary` argument is `TRUE`, the table is not available in a
   #' second connection and is gone after reconnecting.
-  create_temporary_table = function(ctx) {
-    with_connection(ctx = ctx, {
+  create_temporary_table = function(ctx, con) {
+    with_remove_test_table(name = "iris", {
       #' Not all backends support this argument.
       if (!isTRUE(ctx$tweaks$temporary_tables)) {
         skip("tweak: temporary_tables")
       }
 
-      with_remove_test_table(name = "iris", {
-        iris <- get_iris(ctx)[1:30, ]
-        dbCreateTable(con, "iris", iris, temporary = TRUE)
-        iris_out <- check_df(dbReadTable(con, "iris"))
-        expect_equal_df(iris_out, iris[0, , drop = FALSE])
-
-        with_connection(ctx = ctx,
-          expect_error(dbReadTable(con2, "iris")),
-          con = "con2"
-        )
-      })
-    })
-  },
-  # second stage
-  create_temporary_table = function(ctx) {
-    with_connection(ctx = ctx, {
-      expect_error(dbReadTable(con, "iris"))
-    })
-  },
-
-  #' A regular, non-temporary table is visible in a second connection
-  create_table_visible_in_other_connection = function(ctx) {
-    with_connection(ctx = ctx, {
       iris <- get_iris(ctx)[1:30, ]
-
-      dbCreateTable(con, "iris", iris)
+      dbCreateTable(con, "iris", iris, temporary = TRUE)
       iris_out <- check_df(dbReadTable(con, "iris"))
       expect_equal_df(iris_out, iris[0, , drop = FALSE])
 
-      with_connection(ctx = ctx,
-        expect_equal_df(dbReadTable(con2, "iris"), iris[0, , drop = FALSE]),
-        con = "con2"
-      )
+      con2 <- local_connection(ctx)
+      expect_error(dbReadTable(con2, "iris"))
     })
   },
   # second stage
-  create_table_visible_in_other_connection = function(ctx) {
+  create_temporary_table = function(con) {
+    expect_error(dbReadTable(con, "iris"))
+  },
+
+  #' A regular, non-temporary table is visible in a second connection
+  create_table_visible_in_other_connection = function(ctx, con) {
+    iris <- get_iris(ctx)[1:30, ]
+
+    dbCreateTable(con, "iris", iris)
+    iris_out <- check_df(dbReadTable(con, "iris"))
+    expect_equal_df(iris_out, iris[0, , drop = FALSE])
+
+    con2 <- local_connection(ctx)
+    expect_equal_df(dbReadTable(con2, "iris"), iris[0, , drop = FALSE])
+  },
+  # second stage
+  create_table_visible_in_other_connection = function(con) {
     #' and after reconnecting to the database.
-    with_connection(ctx = ctx, {
-      with_remove_test_table(name = "iris", {
-        expect_equal_df(check_df(dbReadTable(con, "iris")), iris[0, , drop = FALSE])
-      })
+    with_remove_test_table(name = "iris", {
+      expect_equal_df(check_df(dbReadTable(con, "iris")), iris[0, , drop = FALSE])
     })
   },
 

--- a/R/spec-sql-create-table.R
+++ b/R/spec-sql-create-table.R
@@ -132,7 +132,9 @@ spec_sql_create_table <- list(
         )
       })
     })
-
+  },
+  # second stage
+  create_temporary_table = function(ctx) {
     with_connection(ctx = ctx, {
       expect_error(dbReadTable(con, "iris"))
     })
@@ -152,7 +154,9 @@ spec_sql_create_table <- list(
         con = "con2"
       )
     })
-
+  },
+  # second stage
+  create_table_visible_in_other_connection = function(ctx) {
     #' and after reconnecting to the database.
     with_connection(ctx = ctx, {
       with_remove_test_table(name = "iris", {

--- a/R/spec-sql-read-table.R
+++ b/R/spec-sql-read-table.R
@@ -193,9 +193,8 @@ spec_sql_read_table <- list(
   read_table_closed_connection = function(ctx, con) {
     with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1))
-      with_closed_connection(ctx = ctx, con = "con2", {
-        expect_error(dbReadTable(con2, "test"))
-      })
+      con2 <- local_closed_connection(ctx = ctx)
+      expect_error(dbReadTable(con2, "test"))
     })
   },
 

--- a/R/spec-sql-read-table.R
+++ b/R/spec-sql-read-table.R
@@ -202,9 +202,8 @@ spec_sql_read_table <- list(
   read_table_invalid_connection = function(ctx, con) {
     with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1))
-      with_invalid_connection(ctx = ctx, con = "con2", {
-        expect_error(dbReadTable(con2, "test"))
-      })
+      con2 <- local_invalid_connection(ctx)
+      expect_error(dbReadTable(con2, "test"))
     })
   },
 

--- a/R/spec-sql-remove-table.R
+++ b/R/spec-sql-remove-table.R
@@ -42,9 +42,8 @@ spec_sql_remove_table <- list(
   remove_table_invalid_connection = function(ctx, con) {
     with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1))
-      with_invalid_connection(ctx = ctx, con = "con2", {
-        expect_error(dbRemoveTable(con2, "test"))
-      })
+      con2 <- local_invalid_connection(ctx)
+      expect_error(dbRemoveTable(con2, "test"))
     })
   },
 

--- a/R/spec-sql-remove-table.R
+++ b/R/spec-sql-remove-table.R
@@ -118,15 +118,14 @@ spec_sql_remove_table <- list(
   #' The removal propagates immediately to other connections to the same database.
   remove_table_other_con = function(ctx, con) {
     with_remove_test_table({
-      with_connection(ctx = ctx, con = "con2", {
-        dbWriteTable(con, "test", data.frame(a = 1L))
-        expect_true("test" %in% dbListTables(con2))
-        expect_true(dbExistsTable(con2, "test"))
+      con2 <- local_connection(ctx)
+      dbWriteTable(con, "test", data.frame(a = 1L))
+      expect_true("test" %in% dbListTables(con2))
+      expect_true(dbExistsTable(con2, "test"))
 
-        dbRemoveTable(con, "test")
-        expect_false("test" %in% dbListTables(con2))
-        expect_false(dbExistsTable(con2, "test"))
-      })
+      dbRemoveTable(con, "test")
+      expect_false("test" %in% dbListTables(con2))
+      expect_false(dbExistsTable(con2, "test"))
     })
   },
 

--- a/R/spec-sql-remove-table.R
+++ b/R/spec-sql-remove-table.R
@@ -33,9 +33,8 @@ spec_sql_remove_table <- list(
   remove_table_closed_connection = function(ctx, con) {
     with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1))
-      with_closed_connection(ctx = ctx, con = "con2", {
-        expect_error(dbRemoveTable(con2, "test"))
-      })
+      con2 <- local_closed_connection(ctx = ctx)
+      expect_error(dbRemoveTable(con2, "test"))
     })
   },
 

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -216,7 +216,9 @@ spec_sql_write_table <- list(
         )
       })
     })
-
+  },
+  # second stage
+  temporary_table = function(ctx) {
     with_connection(ctx = ctx, {
       expect_error(dbReadTable(con, "iris"))
     })

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -229,7 +229,7 @@ spec_sql_write_table <- list(
     con2 <- local_connection(ctx)
     expect_equal_df(dbReadTable(con2, "iris"), iris30)
   },
-  #second stage
+  # second stage
   table_visible_in_other_connection = function(ctx, con) {
     #' and after reconnecting to the database.
     iris30 <- get_iris(ctx)[1:30, ]

--- a/R/spec-transaction-begin-commit-rollback.R
+++ b/R/spec-transaction-begin-commit-rollback.R
@@ -88,36 +88,32 @@ spec_transaction_begin_commit_rollback <- list(
   },
 
   #' Data written in a transaction must persist after the transaction is committed.
-  begin_write_commit = function(ctx) {
-    with_connection(ctx = ctx, {
-      #' For example, a record that is missing when the transaction is started
+  begin_write_commit = function(con) {
+    #' For example, a record that is missing when the transaction is started
 
-      dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
+    dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
-      dbBegin(con)
-      with_rollback_on_error({
-        #' but is created during the transaction
-        dbExecute(con, paste0("INSERT INTO test (a) VALUES (1)"))
+    dbBegin(con)
+    with_rollback_on_error({
+      #' but is created during the transaction
+      dbExecute(con, paste0("INSERT INTO test (a) VALUES (1)"))
 
-        #' must exist
-        expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
-
-        #' both during
-        dbCommit(con)
-      })
-
-      #' and after the transaction,
+      #' must exist
       expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
+
+      #' both during
+      dbCommit(con)
     })
+
+    #' and after the transaction,
+    expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
   },
   # second stage
-  begin_write_commit = function(ctx) {
-    with_connection(ctx = ctx, {
-      with_remove_test_table({
-        #' and also in a new connection.
-        expect_true(dbExistsTable(con, "test"))
-        expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
-      })
+  begin_write_commit = function(con) {
+    with_remove_test_table({
+      #' and also in a new connection.
+      expect_true(dbExistsTable(con, "test"))
+      expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
     })
   },
   #
@@ -147,26 +143,22 @@ spec_transaction_begin_commit_rollback <- list(
     })
   },
   #
-  begin_write_disconnect = function(ctx) {
+  begin_write_disconnect = function(con) {
     #'
     #' Disconnection from a connection with an open transaction
-    with_connection(ctx = ctx, {
-      dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
+    dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
-      dbBegin(con)
+    dbBegin(con)
 
-      dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
-    })
+    dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
   },
   #
-  begin_write_disconnect = function(ctx) {
-    with_connection(ctx = ctx, {
-      #' effectively rolls back the transaction.
-      #' All data written in such a transaction must be removed after the
-      #' transaction is rolled back.
-      with_remove_test_table({
-        expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
-      })
+  begin_write_disconnect = function(con) {
+    #' effectively rolls back the transaction.
+    #' All data written in such a transaction must be removed after the
+    #' transaction is rolled back.
+    with_remove_test_table({
+      expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
     })
   },
 

--- a/R/spec-transaction-begin-commit-rollback.R
+++ b/R/spec-transaction-begin-commit-rollback.R
@@ -109,7 +109,9 @@ spec_transaction_begin_commit_rollback <- list(
       #' and after the transaction,
       expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
     })
-
+  },
+  # second stage
+  begin_write_commit = function(ctx) {
     with_connection(ctx = ctx, {
       with_remove_test_table({
         #' and also in a new connection.
@@ -155,7 +157,9 @@ spec_transaction_begin_commit_rollback <- list(
 
       dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
     })
-
+  },
+  #
+  begin_write_disconnect = function(ctx) {
     with_connection(ctx = ctx, {
       #' effectively rolls back the transaction.
       #' All data written in such a transaction must be removed after the

--- a/R/utils.R
+++ b/R/utils.R
@@ -30,21 +30,6 @@ local_invalid_connection <- function(ctx, ...) {
 
 # Evaluates the code inside local() after defining a variable "con"
 # (can be overridden by specifying con argument)
-# that points to a newly opened connection. Disconnects on exit.
-with_connection <- function(code, con = "con", env = parent.frame(), ctx) {
-  force(ctx)
-
-  quo <- enquo(code)
-
-  con <- as.name(con)
-
-  data <- list2(!!con := local_connection(ctx))
-
-  eval_tidy(quo, data)
-}
-
-# Evaluates the code inside local() after defining a variable "con"
-# (can be overridden by specifying con argument)
 # that points to a newly opened and then closed connection. Disconnects on exit.
 with_closed_connection <- function(code, con = "closed_con", env = parent.frame(), ctx) {
   force(ctx)

--- a/R/utils.R
+++ b/R/utils.R
@@ -30,21 +30,6 @@ local_invalid_connection <- function(ctx, ...) {
 
 # Evaluates the code inside local() after defining a variable "con"
 # (can be overridden by specifying con argument)
-# that points to a newly opened and then closed connection. Disconnects on exit.
-with_closed_connection <- function(code, con = "closed_con", env = parent.frame(), ctx) {
-  force(ctx)
-
-  quo <- enquo(code)
-
-  con <- as.name(con)
-
-  data <- list2(!!con := local_closed_connection(ctx))
-
-  eval_tidy(quo, data)
-}
-
-# Evaluates the code inside local() after defining a variable "con"
-# (can be overridden by specifying con argument)
 # that points to a newly opened but invalidated connection. Disconnects on exit.
 with_invalid_connection <- function(code, con = "invalid_con", env = parent.frame(), ctx) {
   force(ctx)

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,21 +28,6 @@ local_invalid_connection <- function(ctx, ...) {
   unserialize(serialize(con, NULL))
 }
 
-# Evaluates the code inside local() after defining a variable "con"
-# (can be overridden by specifying con argument)
-# that points to a newly opened but invalidated connection. Disconnects on exit.
-with_invalid_connection <- function(code, con = "invalid_con", env = parent.frame(), ctx) {
-  force(ctx)
-
-  quo <- enquo(code)
-
-  con <- as.name(con)
-
-  data <- list2(!!con := local_invalid_connection(ctx))
-
-  eval_tidy(quo, data)
-}
-
 # Evaluates the code inside local() after defining a variable "res"
 # (can be overridden by specifying con argument)
 # that points to a result set created by query. Clears on exit.

--- a/tests/testthat/test-consistency.R
+++ b/tests/testthat/test-consistency.R
@@ -19,6 +19,7 @@ test_that("no duplicate spec names expect known exceptions", {
     "create_temporary_table",
     "create_table_visible_in_other_connection",
     "temporary_table",
+    "table_visible_in_other_connection",
     "begin_write_disconnect",
     "begin_write_commit"
   ))]

--- a/tests/testthat/test-consistency.R
+++ b/tests/testthat/test-consistency.R
@@ -12,8 +12,17 @@ test_that("no unnamed specs", {
   expect_null(vicinity)
 })
 
-test_that("no duplicate spec names", {
+test_that("no duplicate spec names expect known exceptions", {
   all_names <- names(spec_all)
+
+  all_names <- all_names[!(all_names %in% c(
+    "create_temporary_table",
+    "create_table_visible_in_other_connection",
+    "temporary_table",
+    "begin_write_disconnect",
+    "begin_write_commit"
+  ))]
+
   dupe_names <- unique(all_names[duplicated(all_names)])
   expect_equal(dupe_names, rep("", length(dupe_names)))
 })


### PR DESCRIPTION
to get rid of all instances of `with_*connection()`.