### PR TITLE
Support table_name argument

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -117,7 +117,7 @@ patch_test_fun <- function(test_fun, desc) {
 }
 
 wrap_all_statements_with_expect_no_warning <- function(block) {
-  stopifnot(identical(block[[1]], quote(`{`)))
+  # stopifnot(identical(block[[1]], quote(`{`)))
   block[-1] <- lapply(block[-1], function(x) expr(expect_warning(!!x, NA)))
   block
 }

--- a/R/run.R
+++ b/R/run.R
@@ -54,6 +54,16 @@ run_tests <- function(ctx, tests, skip, run_only, test_suite) {
           args <- c(args, list(invalid_con = invalid_con))
         }
 
+        if ("table_name" %in% names(fmls)) {
+          if (rlang::is_missing(fmls$table_name)) {
+            table_name <- random_table_name()
+          } else {
+            table_name <- fmls$table_name
+          }
+          local_remove_test_table(con, table_name)
+          args <- c(args, list(table_name = table_name))
+        }
+
         rlang::exec(test_fun, !!!args)
       }
     },

--- a/R/run.R
+++ b/R/run.R
@@ -32,23 +32,24 @@ run_tests <- function(ctx, tests, skip, run_only, test_suite) {
         FALSE
       } else {
         test_fun <- patch_test_fun(tests[[test_idx]], paste0(test_context, ": ", test_name))
+        fmls <- formals(test_fun)
 
         args <- list()
-        if ("ctx" %in% names(formals(test_fun))) {
+        if ("ctx" %in% names(fmls)) {
           args <- c(args, list(ctx = ctx))
         }
 
-        if ("con" %in% names(formals(test_fun))) {
+        if ("con" %in% names(fmls)) {
           con <- local_connection(ctx)
           args <- c(args, list(con = con))
         }
 
-        if ("closed_con" %in% names(formals(test_fun))) {
+        if ("closed_con" %in% names(fmls)) {
           closed_con <- local_closed_connection(ctx)
           args <- c(args, list(closed_con = closed_con))
         }
 
-        if ("invalid_con" %in% names(formals(test_fun))) {
+        if ("invalid_con" %in% names(fmls)) {
           invalid_con <- local_invalid_connection(ctx)
           args <- c(args, list(invalid_con = invalid_con))
         }

--- a/R/spec-compliance-methods.R
+++ b/R/spec-compliance-methods.R
@@ -42,6 +42,7 @@ spec_compliance_methods <- list(
         expect_has_class_method(method, class, args, where)
       }, names(key_methods[[name]]), key_methods[[name]])
     })
+    #
   },
 
   #' All methods defined in \pkg{DBI} are reexported (so that the package can

--- a/R/spec-meta-column-info.R
+++ b/R/spec-meta-column-info.R
@@ -10,8 +10,7 @@ spec_meta_column_info <- list(
 
   #' @return
   #' `dbColumnInfo()`
-  column_info = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  column_info = function(ctx, con) with_remove_test_table(name = "iris", {
       iris <- get_iris(ctx)
       dbWriteTable(con, "iris", iris)
 
@@ -36,8 +35,7 @@ spec_meta_column_info <- list(
           #' to create a zero-row data frame initialized with the correct data types.
         }
       )
-    })
-  },
+  }), # with_remove_test_table
 
 
   #'
@@ -54,8 +52,7 @@ spec_meta_column_info <- list(
   #' @section Specification:
   #'
   #' A column named `row_names` is treated like any other column.
-  column_info_row_names = function(con) {
-    with_remove_test_table({
+  column_info_row_names = function(con) with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1L, row_names = 2L))
       with_result(
         dbSendQuery(con, "SELECT * FROM test"),
@@ -63,8 +60,7 @@ spec_meta_column_info <- list(
           expect_identical(dbColumnInfo(res)$name, c("a", "row_names"))
         }
       )
-    })
-  },
+  }), # with_remove_test_table
 
   #'
   column_info_consistent = function(ctx, con) {

--- a/R/spec-meta-column-info.R
+++ b/R/spec-meta-column-info.R
@@ -53,7 +53,7 @@ spec_meta_column_info <- list(
   #'
   #' A column named `row_names` is treated like any other column.
   column_info_row_names = function(con, table_name = "test") {
-    dbWriteTable(con, "test", data.frame(a = 1L, row_names = 2L))
+    dbWriteTable(con, table_name, data.frame(a = 1L, row_names = 2L))
     with_result(
       dbSendQuery(con, "SELECT * FROM test"),
       {

--- a/R/spec-meta-column-info.R
+++ b/R/spec-meta-column-info.R
@@ -11,30 +11,30 @@ spec_meta_column_info <- list(
   #' @return
   #' `dbColumnInfo()`
   column_info = function(ctx, con, table_name = "iris") {
-      iris <- get_iris(ctx)
-      dbWriteTable(con, "iris", iris)
+    iris <- get_iris(ctx)
+    dbWriteTable(con, "iris", iris)
 
-      with_result(
-        dbSendQuery(con, "SELECT * FROM iris"),
-        {
-          fields <- dbColumnInfo(res)
-          #' returns a data frame
-          expect_is(fields, "data.frame")
-          #' with at least two columns `"name"` and `"type"` (in that order)
-          expect_equal(names(fields)[1:2], c("name", "type"))
-          #' (and optional columns that start with a dot).
-          expect_true(all(grepl("^[.]", names(fields)[-1:-2])))
+    with_result(
+      dbSendQuery(con, "SELECT * FROM iris"),
+      {
+        fields <- dbColumnInfo(res)
+        #' returns a data frame
+        expect_is(fields, "data.frame")
+        #' with at least two columns `"name"` and `"type"` (in that order)
+        expect_equal(names(fields)[1:2], c("name", "type"))
+        #' (and optional columns that start with a dot).
+        expect_true(all(grepl("^[.]", names(fields)[-1:-2])))
 
-          #' The `"name"` and `"type"` columns contain the names and types
-          #' of the R columns of the data frame that is returned from [`dbFetch()`].
-          iris_ret <- dbFetch(res)
-          expect_identical(fields$name, names(iris_ret))
-          #' The `"type"` column is of type `character` and only for information.
-          expect_is(fields$type, "character")
-          #' Do not compute on the `"type"` column, instead use `dbFetch(res, n = 0)`
-          #' to create a zero-row data frame initialized with the correct data types.
-        }
-      )
+        #' The `"name"` and `"type"` columns contain the names and types
+        #' of the R columns of the data frame that is returned from [`dbFetch()`].
+        iris_ret <- dbFetch(res)
+        expect_identical(fields$name, names(iris_ret))
+        #' The `"type"` column is of type `character` and only for information.
+        expect_is(fields$type, "character")
+        #' Do not compute on the `"type"` column, instead use `dbFetch(res, n = 0)`
+        #' to create a zero-row data frame initialized with the correct data types.
+      }
+    )
   },
 
 
@@ -53,13 +53,13 @@ spec_meta_column_info <- list(
   #'
   #' A column named `row_names` is treated like any other column.
   column_info_row_names = function(con, table_name = "test") {
-      dbWriteTable(con, "test", data.frame(a = 1L, row_names = 2L))
-      with_result(
-        dbSendQuery(con, "SELECT * FROM test"),
-        {
-          expect_identical(dbColumnInfo(res)$name, c("a", "row_names"))
-        }
-      )
+    dbWriteTable(con, "test", data.frame(a = 1L, row_names = 2L))
+    with_result(
+      dbSendQuery(con, "SELECT * FROM test"),
+      {
+        expect_identical(dbColumnInfo(res)$name, c("a", "row_names"))
+      }
+    )
   },
 
   #'

--- a/R/spec-meta-column-info.R
+++ b/R/spec-meta-column-info.R
@@ -10,7 +10,7 @@ spec_meta_column_info <- list(
 
   #' @return
   #' `dbColumnInfo()`
-  column_info = function(ctx, con) with_remove_test_table(name = "iris", {
+  column_info = function(ctx, con, table_name = "iris") {
       iris <- get_iris(ctx)
       dbWriteTable(con, "iris", iris)
 
@@ -35,7 +35,7 @@ spec_meta_column_info <- list(
           #' to create a zero-row data frame initialized with the correct data types.
         }
       )
-  }), # with_remove_test_table
+  },
 
 
   #'
@@ -52,7 +52,7 @@ spec_meta_column_info <- list(
   #' @section Specification:
   #'
   #' A column named `row_names` is treated like any other column.
-  column_info_row_names = function(con) with_remove_test_table(name = "test", {
+  column_info_row_names = function(con, table_name = "test") {
       dbWriteTable(con, "test", data.frame(a = 1L, row_names = 2L))
       with_result(
         dbSendQuery(con, "SELECT * FROM test"),
@@ -60,7 +60,7 @@ spec_meta_column_info <- list(
           expect_identical(dbColumnInfo(res)$name, c("a", "row_names"))
         }
       )
-  }), # with_remove_test_table
+  },
 
   #'
   column_info_consistent = function(ctx, con) {

--- a/R/spec-meta-column-info.R
+++ b/R/spec-meta-column-info.R
@@ -52,7 +52,7 @@ spec_meta_column_info <- list(
   #' @section Specification:
   #'
   #' A column named `row_names` is treated like any other column.
-  column_info_row_names = function(con) with_remove_test_table({
+  column_info_row_names = function(con) with_remove_test_table(name = "test", {
       dbWriteTable(con, "test", data.frame(a = 1L, row_names = 2L))
       with_result(
         dbSendQuery(con, "SELECT * FROM test"),

--- a/R/spec-meta-get-row-count.R
+++ b/R/spec-meta-get-row-count.R
@@ -68,8 +68,7 @@ spec_meta_get_row_count <- list(
     )
   },
   #
-  row_count_statement = function(con) {
-    with_remove_test_table(name = table_name <- random_table_name(), {
+  row_count_statement = function(con) with_remove_test_table(name = table_name <- random_table_name(), {
       query <- paste0("CREATE TABLE ", table_name, " (a integer)")
       with_result(
         #' For data manipulation statements issued with
@@ -85,8 +84,7 @@ spec_meta_get_row_count <- list(
           expect_equal(rc, 0L)
         }
       )
-    })
-  },
+  }), # with_remove_test_table
   #
   get_row_count_error = function(con) {
     res <- dbSendQuery(con, trivial_query())

--- a/R/spec-meta-get-row-count.R
+++ b/R/spec-meta-get-row-count.R
@@ -69,21 +69,21 @@ spec_meta_get_row_count <- list(
   },
   #
   row_count_statement = function(con, table_name) {
-      query <- paste0("CREATE TABLE ", table_name, " (a integer)")
-      with_result(
-        #' For data manipulation statements issued with
-        #' [dbSendStatement()],
-        dbSendStatement(con, query),
-        {
-          rc <- dbGetRowCount(res)
-          #' zero is returned before
-          expect_equal(rc, 0L)
-          expect_warning(check_df(dbFetch(res)))
-          rc <- dbGetRowCount(res)
-          #' and after calling `dbFetch()`.
-          expect_equal(rc, 0L)
-        }
-      )
+    query <- paste0("CREATE TABLE ", table_name, " (a integer)")
+    with_result(
+      #' For data manipulation statements issued with
+      #' [dbSendStatement()],
+      dbSendStatement(con, query),
+      {
+        rc <- dbGetRowCount(res)
+        #' zero is returned before
+        expect_equal(rc, 0L)
+        expect_warning(check_df(dbFetch(res)))
+        rc <- dbGetRowCount(res)
+        #' and after calling `dbFetch()`.
+        expect_equal(rc, 0L)
+      }
+    )
   },
   #
   get_row_count_error = function(con) {

--- a/R/spec-meta-get-row-count.R
+++ b/R/spec-meta-get-row-count.R
@@ -68,7 +68,7 @@ spec_meta_get_row_count <- list(
     )
   },
   #
-  row_count_statement = function(con) with_remove_test_table(name = table_name <- random_table_name(), {
+  row_count_statement = function(con, table_name) {
       query <- paste0("CREATE TABLE ", table_name, " (a integer)")
       with_result(
         #' For data manipulation statements issued with
@@ -84,7 +84,7 @@ spec_meta_get_row_count <- list(
           expect_equal(rc, 0L)
         }
       )
-  }), # with_remove_test_table
+  },
   #
   get_row_count_error = function(con) {
     res <- dbSendQuery(con, trivial_query())

--- a/R/spec-meta-get-rows-affected.R
+++ b/R/spec-meta-get-rows-affected.R
@@ -11,8 +11,7 @@ spec_meta_get_rows_affected <- list(
   #' @return
   #' `dbGetRowsAffected()` returns a scalar number (integer or numeric),
   #' the number of rows affected by a data manipulation statement
-  rows_affected_statement = function(con) {
-    with_remove_test_table({
+  rows_affected_statement = function(con) with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1:10))
 
       query <- paste0(
@@ -32,8 +31,7 @@ spec_meta_get_rows_affected <- list(
           expect_equal(rc, 5L)
         }
       )
-    })
-  },
+  }), # with_remove_test_table
   #
   rows_affected_query = function(con) {
     query <- trivial_query()
@@ -52,8 +50,7 @@ spec_meta_get_rows_affected <- list(
     )
   },
   #
-  get_rows_affected_error = function(con) {
-    with_remove_test_table({
+  get_rows_affected_error = function(con) with_remove_test_table({
       query <- paste0(
         "CREATE TABLE ", dbQuoteIdentifier(con, "test"), " (a integer)"
       )
@@ -62,8 +59,7 @@ spec_meta_get_rows_affected <- list(
       #' Attempting to get the rows affected for a result set cleared with
       #' [dbClearResult()] gives an error.
       expect_error(dbGetRowsAffected(res))
-    })
-  },
+  }), # with_remove_test_table
   #
   NULL
 )

--- a/R/spec-meta-get-rows-affected.R
+++ b/R/spec-meta-get-rows-affected.R
@@ -12,10 +12,10 @@ spec_meta_get_rows_affected <- list(
   #' `dbGetRowsAffected()` returns a scalar number (integer or numeric),
   #' the number of rows affected by a data manipulation statement
   rows_affected_statement = function(con, table_name = "test") {
-    dbWriteTable(con, "test", data.frame(a = 1:10))
+    dbWriteTable(con, table_name, data.frame(a = 1:10))
 
     query <- paste0(
-      "DELETE FROM ", dbQuoteIdentifier(con, "test"), " ",
+      "DELETE FROM ", dbQuoteIdentifier(con, table_name), " ",
       "WHERE a < 6"
     )
     with_result(
@@ -52,7 +52,7 @@ spec_meta_get_rows_affected <- list(
   #
   get_rows_affected_error = function(con, table_name = "test") {
     query <- paste0(
-      "CREATE TABLE ", dbQuoteIdentifier(con, "test"), " (a integer)"
+      "CREATE TABLE ", dbQuoteIdentifier(con, table_name), " (a integer)"
     )
     res <- dbSendStatement(con, query)
     dbClearResult(res)

--- a/R/spec-meta-get-rows-affected.R
+++ b/R/spec-meta-get-rows-affected.R
@@ -12,25 +12,25 @@ spec_meta_get_rows_affected <- list(
   #' `dbGetRowsAffected()` returns a scalar number (integer or numeric),
   #' the number of rows affected by a data manipulation statement
   rows_affected_statement = function(con, table_name = "test") {
-      dbWriteTable(con, "test", data.frame(a = 1:10))
+    dbWriteTable(con, "test", data.frame(a = 1:10))
 
-      query <- paste0(
-        "DELETE FROM ", dbQuoteIdentifier(con, "test"), " ",
-        "WHERE a < 6"
-      )
-      with_result(
-        #' issued with [dbSendStatement()].
-        dbSendStatement(con, query),
-        {
-          rc <- dbGetRowsAffected(res)
-          #' The value is available directly after the call
-          expect_equal(rc, 5L)
-          expect_warning(check_df(dbFetch(res)))
-          rc <- dbGetRowsAffected(res)
-          #' and does not change after calling [dbFetch()].
-          expect_equal(rc, 5L)
-        }
-      )
+    query <- paste0(
+      "DELETE FROM ", dbQuoteIdentifier(con, "test"), " ",
+      "WHERE a < 6"
+    )
+    with_result(
+      #' issued with [dbSendStatement()].
+      dbSendStatement(con, query),
+      {
+        rc <- dbGetRowsAffected(res)
+        #' The value is available directly after the call
+        expect_equal(rc, 5L)
+        expect_warning(check_df(dbFetch(res)))
+        rc <- dbGetRowsAffected(res)
+        #' and does not change after calling [dbFetch()].
+        expect_equal(rc, 5L)
+      }
+    )
   },
   #
   rows_affected_query = function(con) {
@@ -51,14 +51,14 @@ spec_meta_get_rows_affected <- list(
   },
   #
   get_rows_affected_error = function(con, table_name = "test") {
-      query <- paste0(
-        "CREATE TABLE ", dbQuoteIdentifier(con, "test"), " (a integer)"
-      )
-      res <- dbSendStatement(con, query)
-      dbClearResult(res)
-      #' Attempting to get the rows affected for a result set cleared with
-      #' [dbClearResult()] gives an error.
-      expect_error(dbGetRowsAffected(res))
+    query <- paste0(
+      "CREATE TABLE ", dbQuoteIdentifier(con, "test"), " (a integer)"
+    )
+    res <- dbSendStatement(con, query)
+    dbClearResult(res)
+    #' Attempting to get the rows affected for a result set cleared with
+    #' [dbClearResult()] gives an error.
+    expect_error(dbGetRowsAffected(res))
   },
   #
   NULL

--- a/R/spec-meta-get-rows-affected.R
+++ b/R/spec-meta-get-rows-affected.R
@@ -11,7 +11,7 @@ spec_meta_get_rows_affected <- list(
   #' @return
   #' `dbGetRowsAffected()` returns a scalar number (integer or numeric),
   #' the number of rows affected by a data manipulation statement
-  rows_affected_statement = function(con) with_remove_test_table({
+  rows_affected_statement = function(con) with_remove_test_table(name = "test", {
       dbWriteTable(con, "test", data.frame(a = 1:10))
 
       query <- paste0(
@@ -50,7 +50,7 @@ spec_meta_get_rows_affected <- list(
     )
   },
   #
-  get_rows_affected_error = function(con) with_remove_test_table({
+  get_rows_affected_error = function(con) with_remove_test_table(name = "test", {
       query <- paste0(
         "CREATE TABLE ", dbQuoteIdentifier(con, "test"), " (a integer)"
       )

--- a/R/spec-meta-get-rows-affected.R
+++ b/R/spec-meta-get-rows-affected.R
@@ -11,7 +11,7 @@ spec_meta_get_rows_affected <- list(
   #' @return
   #' `dbGetRowsAffected()` returns a scalar number (integer or numeric),
   #' the number of rows affected by a data manipulation statement
-  rows_affected_statement = function(con) with_remove_test_table(name = "test", {
+  rows_affected_statement = function(con, table_name = "test") {
       dbWriteTable(con, "test", data.frame(a = 1:10))
 
       query <- paste0(
@@ -31,7 +31,7 @@ spec_meta_get_rows_affected <- list(
           expect_equal(rc, 5L)
         }
       )
-  }), # with_remove_test_table
+  },
   #
   rows_affected_query = function(con) {
     query <- trivial_query()
@@ -50,7 +50,7 @@ spec_meta_get_rows_affected <- list(
     )
   },
   #
-  get_rows_affected_error = function(con) with_remove_test_table(name = "test", {
+  get_rows_affected_error = function(con, table_name = "test") {
       query <- paste0(
         "CREATE TABLE ", dbQuoteIdentifier(con, "test"), " (a integer)"
       )
@@ -59,7 +59,7 @@ spec_meta_get_rows_affected <- list(
       #' Attempting to get the rows affected for a result set cleared with
       #' [dbClearResult()] gives an error.
       expect_error(dbGetRowsAffected(res))
-  }), # with_remove_test_table
+  },
   #
   NULL
 )

--- a/R/spec-meta-get-statement.R
+++ b/R/spec-meta-get-statement.R
@@ -23,7 +23,7 @@ spec_meta_get_statement <- list(
     )
   },
   #
-  get_statement_statement = function(con) with_remove_test_table(name = table_name <- random_table_name(), {
+  get_statement_statement = function(con, table_name) {
       query <- paste0("CREATE TABLE ", table_name, " (a integer)")
       with_result(
         #' or [dbSendStatement()].
@@ -34,7 +34,7 @@ spec_meta_get_statement <- list(
           expect_identical(s, query)
         }
       )
-  }), # with_remove_test_table
+  },
   #
   get_statement_error = function(con) {
     res <- dbSendQuery(con, trivial_query())

--- a/R/spec-meta-get-statement.R
+++ b/R/spec-meta-get-statement.R
@@ -24,16 +24,16 @@ spec_meta_get_statement <- list(
   },
   #
   get_statement_statement = function(con, table_name) {
-      query <- paste0("CREATE TABLE ", table_name, " (a integer)")
-      with_result(
-        #' or [dbSendStatement()].
-        dbSendStatement(con, query),
-        {
-          s <- dbGetStatement(res)
-          expect_is(s, "character")
-          expect_identical(s, query)
-        }
-      )
+    query <- paste0("CREATE TABLE ", table_name, " (a integer)")
+    with_result(
+      #' or [dbSendStatement()].
+      dbSendStatement(con, query),
+      {
+        s <- dbGetStatement(res)
+        expect_is(s, "character")
+        expect_identical(s, query)
+      }
+    )
   },
   #
   get_statement_error = function(con) {

--- a/R/spec-meta-get-statement.R
+++ b/R/spec-meta-get-statement.R
@@ -23,8 +23,7 @@ spec_meta_get_statement <- list(
     )
   },
   #
-  get_statement_statement = function(con) {
-    with_remove_test_table(name = table_name <- random_table_name(), {
+  get_statement_statement = function(con) with_remove_test_table(name = table_name <- random_table_name(), {
       query <- paste0("CREATE TABLE ", table_name, " (a integer)")
       with_result(
         #' or [dbSendStatement()].
@@ -35,8 +34,7 @@ spec_meta_get_statement <- list(
           expect_identical(s, query)
         }
       )
-    })
-  },
+  }), # with_remove_test_table
   #
   get_statement_error = function(con) {
     res <- dbSendQuery(con, trivial_query())

--- a/R/spec-meta-has-completed.R
+++ b/R/spec-meta-has-completed.R
@@ -24,8 +24,7 @@ spec_meta_has_completed <- list(
     )
   },
   #
-  has_completed_statement = function(con) {
-    with_remove_test_table(name = table_name <- random_table_name(), {
+  has_completed_statement = function(con) with_remove_test_table(name = table_name <- random_table_name(), {
       #' For a query initiated by [dbSendStatement()],
       with_result(
         dbSendStatement(con, paste0("CREATE TABLE ", table_name, " (a integer)")),
@@ -34,8 +33,7 @@ spec_meta_has_completed <- list(
           expect_true(expect_visible(dbHasCompleted(res)))
         }
       )
-    })
-  },
+  }), # with_remove_test_table
   #
   has_completed_error = function(con) {
     res <- dbSendQuery(con, trivial_query())

--- a/R/spec-meta-has-completed.R
+++ b/R/spec-meta-has-completed.R
@@ -24,7 +24,7 @@ spec_meta_has_completed <- list(
     )
   },
   #
-  has_completed_statement = function(con) with_remove_test_table(name = table_name <- random_table_name(), {
+  has_completed_statement = function(con, table_name) {
       #' For a query initiated by [dbSendStatement()],
       with_result(
         dbSendStatement(con, paste0("CREATE TABLE ", table_name, " (a integer)")),
@@ -33,7 +33,7 @@ spec_meta_has_completed <- list(
           expect_true(expect_visible(dbHasCompleted(res)))
         }
       )
-  }), # with_remove_test_table
+  },
   #
   has_completed_error = function(con) {
     res <- dbSendQuery(con, trivial_query())

--- a/R/spec-meta-has-completed.R
+++ b/R/spec-meta-has-completed.R
@@ -25,14 +25,14 @@ spec_meta_has_completed <- list(
   },
   #
   has_completed_statement = function(con, table_name) {
-      #' For a query initiated by [dbSendStatement()],
-      with_result(
-        dbSendStatement(con, paste0("CREATE TABLE ", table_name, " (a integer)")),
-        {
-          #' `dbHasCompleted()` always returns `TRUE`.
-          expect_true(expect_visible(dbHasCompleted(res)))
-        }
-      )
+    #' For a query initiated by [dbSendStatement()],
+    with_result(
+      dbSendStatement(con, paste0("CREATE TABLE ", table_name, " (a integer)")),
+      {
+        #' `dbHasCompleted()` always returns `TRUE`.
+        expect_true(expect_visible(dbHasCompleted(res)))
+      }
+    )
   },
   #
   has_completed_error = function(con) {

--- a/R/spec-meta-is-valid.R
+++ b/R/spec-meta-is-valid.R
@@ -40,8 +40,7 @@ spec_meta_is_valid <- list(
     expect_false(dbIsValid(res))
   },
   #
-  is_valid_result_statement = function(con) {
-    with_remove_test_table({
+  is_valid_result_statement = function(con) with_remove_test_table({
       query <- paste0("CREATE TABLE test (a ", dbDataType(con, 1L), ")")
       res <- dbSendStatement(con, query)
       #' A [DBIResult-class] object is also valid after a call to [dbSendStatement()],
@@ -52,8 +51,7 @@ spec_meta_is_valid <- list(
       dbClearResult(res)
       #' only clearing it with [dbClearResult()] invalidates it.
       expect_false(dbIsValid(res))
-    })
-  },
+  }), # with_remove_test_table
 
   #' If the connection to the database system is dropped (e.g., due to
   #' connectivity problems, server failure, etc.), `dbIsValid()` should return

--- a/R/spec-meta-is-valid.R
+++ b/R/spec-meta-is-valid.R
@@ -41,16 +41,16 @@ spec_meta_is_valid <- list(
   },
   #
   is_valid_result_statement = function(con, table_name = "test") {
-      query <- paste0("CREATE TABLE test (a ", dbDataType(con, 1L), ")")
-      res <- dbSendStatement(con, query)
-      #' A [DBIResult-class] object is also valid after a call to [dbSendStatement()],
-      expect_true(expect_visible(dbIsValid(res)))
-      #' and stays valid after querying the number of rows affected;
-      expect_error(dbGetRowsAffected(res), NA)
-      expect_true(expect_visible(dbIsValid(res)))
-      dbClearResult(res)
-      #' only clearing it with [dbClearResult()] invalidates it.
-      expect_false(dbIsValid(res))
+    query <- paste0("CREATE TABLE test (a ", dbDataType(con, 1L), ")")
+    res <- dbSendStatement(con, query)
+    #' A [DBIResult-class] object is also valid after a call to [dbSendStatement()],
+    expect_true(expect_visible(dbIsValid(res)))
+    #' and stays valid after querying the number of rows affected;
+    expect_error(dbGetRowsAffected(res), NA)
+    expect_true(expect_visible(dbIsValid(res)))
+    dbClearResult(res)
+    #' only clearing it with [dbClearResult()] invalidates it.
+    expect_false(dbIsValid(res))
   },
 
   #' If the connection to the database system is dropped (e.g., due to

--- a/R/spec-meta-is-valid.R
+++ b/R/spec-meta-is-valid.R
@@ -40,7 +40,7 @@ spec_meta_is_valid <- list(
     expect_false(dbIsValid(res))
   },
   #
-  is_valid_result_statement = function(con) with_remove_test_table(name = "test", {
+  is_valid_result_statement = function(con, table_name = "test") {
       query <- paste0("CREATE TABLE test (a ", dbDataType(con, 1L), ")")
       res <- dbSendStatement(con, query)
       #' A [DBIResult-class] object is also valid after a call to [dbSendStatement()],
@@ -51,7 +51,7 @@ spec_meta_is_valid <- list(
       dbClearResult(res)
       #' only clearing it with [dbClearResult()] invalidates it.
       expect_false(dbIsValid(res))
-  }), # with_remove_test_table
+  },
 
   #' If the connection to the database system is dropped (e.g., due to
   #' connectivity problems, server failure, etc.), `dbIsValid()` should return

--- a/R/spec-meta-is-valid.R
+++ b/R/spec-meta-is-valid.R
@@ -40,7 +40,7 @@ spec_meta_is_valid <- list(
     expect_false(dbIsValid(res))
   },
   #
-  is_valid_result_statement = function(con) with_remove_test_table({
+  is_valid_result_statement = function(con) with_remove_test_table(name = "test", {
       query <- paste0("CREATE TABLE test (a ", dbDataType(con, 1L), ")")
       res <- dbSendStatement(con, query)
       #' A [DBIResult-class] object is also valid after a call to [dbSendStatement()],

--- a/R/spec-result-clear-result.R
+++ b/R/spec-result-clear-result.R
@@ -17,10 +17,10 @@ spec_result_clear_result <- list(
   },
 
   #' and `dbSendStatement()`.
-  clear_result_return_statement = function(con) with_remove_test_table(name = table_name <- random_table_name(), {
+  clear_result_return_statement = function(con, table_name) {
       res <- dbSendStatement(con, paste0("CREATE TABLE ", table_name, " AS SELECT 1"))
       expect_invisible_true(dbClearResult(res))
-  }), # with_remove_test_table
+  },
 
   #' An attempt to close an already closed result set issues a warning
   cannot_clear_result_twice_query = function(con) {
@@ -30,11 +30,11 @@ spec_result_clear_result <- list(
   },
 
   #' in both cases.
-  cannot_clear_result_twice_statement = function(con) with_remove_test_table(name = table_name <- random_table_name(), {
+  cannot_clear_result_twice_statement = function(con, table_name) {
       res <- dbSendStatement(con, paste0("CREATE TABLE ", table_name, " AS SELECT 1"))
       dbClearResult(res)
       expect_warning(expect_invisible_true(dbClearResult(res)))
-  }), # with_remove_test_table
+  },
 
   #' @section Specification:
   #' `dbClearResult()` frees all resources associated with retrieving

--- a/R/spec-result-clear-result.R
+++ b/R/spec-result-clear-result.R
@@ -18,8 +18,8 @@ spec_result_clear_result <- list(
 
   #' and `dbSendStatement()`.
   clear_result_return_statement = function(con, table_name) {
-      res <- dbSendStatement(con, paste0("CREATE TABLE ", table_name, " AS SELECT 1"))
-      expect_invisible_true(dbClearResult(res))
+    res <- dbSendStatement(con, paste0("CREATE TABLE ", table_name, " AS SELECT 1"))
+    expect_invisible_true(dbClearResult(res))
   },
 
   #' An attempt to close an already closed result set issues a warning
@@ -31,9 +31,9 @@ spec_result_clear_result <- list(
 
   #' in both cases.
   cannot_clear_result_twice_statement = function(con, table_name) {
-      res <- dbSendStatement(con, paste0("CREATE TABLE ", table_name, " AS SELECT 1"))
-      dbClearResult(res)
-      expect_warning(expect_invisible_true(dbClearResult(res)))
+    res <- dbSendStatement(con, paste0("CREATE TABLE ", table_name, " AS SELECT 1"))
+    dbClearResult(res)
+    expect_warning(expect_invisible_true(dbClearResult(res)))
   },
 
   #' @section Specification:

--- a/R/spec-result-clear-result.R
+++ b/R/spec-result-clear-result.R
@@ -17,12 +17,10 @@ spec_result_clear_result <- list(
   },
 
   #' and `dbSendStatement()`.
-  clear_result_return_statement = function(con) {
-    with_remove_test_table(name = table_name <- random_table_name(), {
+  clear_result_return_statement = function(con) with_remove_test_table(name = table_name <- random_table_name(), {
       res <- dbSendStatement(con, paste0("CREATE TABLE ", table_name, " AS SELECT 1"))
       expect_invisible_true(dbClearResult(res))
-    })
-  },
+  }), # with_remove_test_table
 
   #' An attempt to close an already closed result set issues a warning
   cannot_clear_result_twice_query = function(con) {
@@ -32,13 +30,11 @@ spec_result_clear_result <- list(
   },
 
   #' in both cases.
-  cannot_clear_result_twice_statement = function(con) {
-    with_remove_test_table(name = table_name <- random_table_name(), {
+  cannot_clear_result_twice_statement = function(con) with_remove_test_table(name = table_name <- random_table_name(), {
       res <- dbSendStatement(con, paste0("CREATE TABLE ", table_name, " AS SELECT 1"))
       dbClearResult(res)
       expect_warning(expect_invisible_true(dbClearResult(res)))
-    })
-  },
+  }), # with_remove_test_table
 
   #' @section Specification:
   #' `dbClearResult()` frees all resources associated with retrieving

--- a/R/spec-result-create-table-with-data-type.R
+++ b/R/spec-result-create-table-with-data-type.R
@@ -8,7 +8,7 @@ spec_result_create_table_with_data_type <- list(
   #' of the form
   data_type_create_table = function(ctx, con) {
     check_connection_data_type <- function(value) {
-      with_remove_test_table({
+      with_remove_test_table(name = "test", {
         #' `"CREATE TABLE test (a ...)"`.
         query <- paste0("CREATE TABLE test (a ", dbDataType(con, value), ")")
         eval(bquote(dbExecute(con, .(query))))

--- a/R/spec-result-execute.R
+++ b/R/spec-result-execute.R
@@ -10,7 +10,7 @@ spec_result_execute <- list(
 
   #' @return
   #' `dbExecute()` always returns a
-  execute_atomic = function(con) with_remove_test_table(name = "test", {
+  execute_atomic = function(con, table_name = "test") {
       query <- trivial_statement()
 
       ret <- dbExecute(con, query)
@@ -20,7 +20,7 @@ spec_result_execute <- list(
       expect_true(is.numeric(ret))
       #' that specifies the number of rows affected
       #' by the statement.
-  }), # with_remove_test_table
+  },
 
   #' An error is raised when issuing a statement over a closed
   execute_closed_connection = function(ctx, closed_con) {
@@ -74,10 +74,10 @@ spec_result_execute <- list(
   },
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
-  execute_immediate = function(con) with_remove_test_table(name = "test", {
+  execute_immediate = function(con, table_name = "test") {
       res <- expect_visible(dbExecute(con, trivial_statement(), immediate = TRUE))
       expect_true(is.numeric(res))
-  }), # with_remove_test_table
+  },
   #
   NULL
 )

--- a/R/spec-result-execute.R
+++ b/R/spec-result-execute.R
@@ -10,7 +10,7 @@ spec_result_execute <- list(
 
   #' @return
   #' `dbExecute()` always returns a
-  execute_atomic = function(con) with_remove_test_table({
+  execute_atomic = function(con) with_remove_test_table(name = "test", {
       query <- trivial_statement()
 
       ret <- dbExecute(con, query)
@@ -74,7 +74,7 @@ spec_result_execute <- list(
   },
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
-  execute_immediate = function(con) with_remove_test_table({
+  execute_immediate = function(con) with_remove_test_table(name = "test", {
       res <- expect_visible(dbExecute(con, trivial_statement(), immediate = TRUE))
       expect_true(is.numeric(res))
   }), # with_remove_test_table

--- a/R/spec-result-execute.R
+++ b/R/spec-result-execute.R
@@ -11,15 +11,15 @@ spec_result_execute <- list(
   #' @return
   #' `dbExecute()` always returns a
   execute_atomic = function(con, table_name = "test") {
-      query <- trivial_statement()
+    query <- trivial_statement()
 
-      ret <- dbExecute(con, query)
-      #' scalar
-      expect_equal(length(ret), 1)
-      #' numeric
-      expect_true(is.numeric(ret))
-      #' that specifies the number of rows affected
-      #' by the statement.
+    ret <- dbExecute(con, query)
+    #' scalar
+    expect_equal(length(ret), 1)
+    #' numeric
+    expect_true(is.numeric(ret))
+    #' that specifies the number of rows affected
+    #' by the statement.
   },
 
   #' An error is raised when issuing a statement over a closed
@@ -75,8 +75,8 @@ spec_result_execute <- list(
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
   execute_immediate = function(con, table_name = "test") {
-      res <- expect_visible(dbExecute(con, trivial_statement(), immediate = TRUE))
-      expect_true(is.numeric(res))
+    res <- expect_visible(dbExecute(con, trivial_statement(), immediate = TRUE))
+    expect_true(is.numeric(res))
   },
   #
   NULL

--- a/R/spec-result-execute.R
+++ b/R/spec-result-execute.R
@@ -60,9 +60,10 @@ spec_result_execute <- list(
   execute_params = function(ctx, con) {
     placeholder_funs <- get_placeholder_funs(ctx)
 
+    table_name <- "test"
     for (placeholder_fun in placeholder_funs) {
-      with_remove_test_table(name = "test", {
-        dbWriteTable(con, "test", data.frame(a = as.numeric(1:3)))
+      with_remove_test_table(name = table_name, {
+        dbWriteTable(con, table_name, data.frame(a = as.numeric(1:3)))
         placeholder <- placeholder_fun(1)
         query <- paste0("DELETE FROM test WHERE a > ", placeholder)
         values <- 1.5

--- a/R/spec-result-execute.R
+++ b/R/spec-result-execute.R
@@ -10,8 +10,7 @@ spec_result_execute <- list(
 
   #' @return
   #' `dbExecute()` always returns a
-  execute_atomic = function(con) {
-    with_remove_test_table({
+  execute_atomic = function(con) with_remove_test_table({
       query <- trivial_statement()
 
       ret <- dbExecute(con, query)
@@ -21,8 +20,7 @@ spec_result_execute <- list(
       expect_true(is.numeric(ret))
       #' that specifies the number of rows affected
       #' by the statement.
-    })
-  },
+  }), # with_remove_test_table
 
   #' An error is raised when issuing a statement over a closed
   execute_closed_connection = function(ctx, closed_con) {
@@ -76,12 +74,10 @@ spec_result_execute <- list(
   },
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
-  execute_immediate = function(con) {
-    with_remove_test_table({
+  execute_immediate = function(con) with_remove_test_table({
       res <- expect_visible(dbExecute(con, trivial_statement(), immediate = TRUE))
       expect_true(is.numeric(res))
-    })
-  },
+  }), # with_remove_test_table
   #
   NULL
 )

--- a/R/spec-result-fetch.R
+++ b/R/spec-result-fetch.R
@@ -93,15 +93,15 @@ spec_result_fetch <- list(
   #' created by [dbSendStatement()]
   #' can be fetched and return an empty data frame, with a warning.
   fetch_no_return_value = function(con, table_name = "test") {
-      query <- "CREATE TABLE test (a integer)"
+    query <- "CREATE TABLE test (a integer)"
 
-      with_result(
-        dbSendStatement(con, query),
-        {
-          expect_warning(rows <- check_df(dbFetch(res)))
-          expect_identical(rows, data.frame())
-        }
-      )
+    with_result(
+      dbSendStatement(con, query),
+      {
+        expect_warning(rows <- check_df(dbFetch(res)))
+        expect_identical(rows, data.frame())
+      }
+    )
   },
 
   #' @section Specification:

--- a/R/spec-result-fetch.R
+++ b/R/spec-result-fetch.R
@@ -92,7 +92,7 @@ spec_result_fetch <- list(
   #' Calling `dbFetch()` on a result set from a data manipulation query
   #' created by [dbSendStatement()]
   #' can be fetched and return an empty data frame, with a warning.
-  fetch_no_return_value = function(con) with_remove_test_table(name = "test", {
+  fetch_no_return_value = function(con, table_name = "test") {
       query <- "CREATE TABLE test (a integer)"
 
       with_result(
@@ -102,7 +102,7 @@ spec_result_fetch <- list(
           expect_identical(rows, data.frame())
         }
       )
-  }), # with_remove_test_table
+  },
 
   #' @section Specification:
   #' Fetching multi-row queries with one

--- a/R/spec-result-fetch.R
+++ b/R/spec-result-fetch.R
@@ -92,8 +92,7 @@ spec_result_fetch <- list(
   #' Calling `dbFetch()` on a result set from a data manipulation query
   #' created by [dbSendStatement()]
   #' can be fetched and return an empty data frame, with a warning.
-  fetch_no_return_value = function(con) {
-    with_remove_test_table({
+  fetch_no_return_value = function(con) with_remove_test_table({
       query <- "CREATE TABLE test (a integer)"
 
       with_result(
@@ -103,8 +102,7 @@ spec_result_fetch <- list(
           expect_identical(rows, data.frame())
         }
       )
-    })
-  },
+  }), # with_remove_test_table
 
   #' @section Specification:
   #' Fetching multi-row queries with one

--- a/R/spec-result-fetch.R
+++ b/R/spec-result-fetch.R
@@ -92,7 +92,7 @@ spec_result_fetch <- list(
   #' Calling `dbFetch()` on a result set from a data manipulation query
   #' created by [dbSendStatement()]
   #' can be fetched and return an empty data frame, with a warning.
-  fetch_no_return_value = function(con) with_remove_test_table({
+  fetch_no_return_value = function(con) with_remove_test_table(name = "test", {
       query <- "CREATE TABLE test (a integer)"
 
       with_result(

--- a/R/spec-result-get-query.R
+++ b/R/spec-result-get-query.R
@@ -209,8 +209,8 @@ spec_result_get_query <- list(
   #'         1. `params` not given: waiting for parameters via [dbBind()]
   #'         1. `params` given: query is executed
   get_query_immediate = function(con, table_name = "test") {
-      res <- expect_visible(dbGetQuery(con, trivial_query(), immediate = TRUE))
-      expect_s3_class(res, "data.frame")
+    res <- expect_visible(dbGetQuery(con, trivial_query(), immediate = TRUE))
+    expect_s3_class(res, "data.frame")
   },
   #
   NULL

--- a/R/spec-result-get-query.R
+++ b/R/spec-result-get-query.R
@@ -208,12 +208,10 @@ spec_result_get_query <- list(
   #'     1. A query with parameters is passed:
   #'         1. `params` not given: waiting for parameters via [dbBind()]
   #'         1. `params` given: query is executed
-  get_query_immediate = function(con) {
-    with_remove_test_table({
+  get_query_immediate = function(con) with_remove_test_table({
       res <- expect_visible(dbGetQuery(con, trivial_query(), immediate = TRUE))
       expect_s3_class(res, "data.frame")
-    })
-  },
+  }), # with_remove_test_table
   #
   NULL
 )

--- a/R/spec-result-get-query.R
+++ b/R/spec-result-get-query.R
@@ -208,10 +208,10 @@ spec_result_get_query <- list(
   #'     1. A query with parameters is passed:
   #'         1. `params` not given: waiting for parameters via [dbBind()]
   #'         1. `params` given: query is executed
-  get_query_immediate = function(con) with_remove_test_table(name = "test", {
+  get_query_immediate = function(con, table_name = "test") {
       res <- expect_visible(dbGetQuery(con, trivial_query(), immediate = TRUE))
       expect_s3_class(res, "data.frame")
-  }), # with_remove_test_table
+  },
   #
   NULL
 )

--- a/R/spec-result-get-query.R
+++ b/R/spec-result-get-query.R
@@ -208,7 +208,7 @@ spec_result_get_query <- list(
   #'     1. A query with parameters is passed:
   #'         1. `params` not given: waiting for parameters via [dbBind()]
   #'         1. `params` given: query is executed
-  get_query_immediate = function(con) with_remove_test_table({
+  get_query_immediate = function(con) with_remove_test_table(name = "test", {
       res <- expect_visible(dbGetQuery(con, trivial_query(), immediate = TRUE))
       expect_s3_class(res, "data.frame")
   }), # with_remove_test_table

--- a/R/spec-result-send-query.R
+++ b/R/spec-result-send-query.R
@@ -107,12 +107,12 @@ spec_result_send_query <- list(
   },
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
-  send_query_immediate = function(con) with_remove_test_table(name = "test", {
+  send_query_immediate = function(con, table_name = "test") {
       res <- expect_visible(dbSendQuery(con, trivial_query(), immediate = TRUE))
       expect_s4_class(res, "DBIResult")
       expect_error(dbGetRowsAffected(res), NA)
       dbClearResult(res)
-  }), # with_remove_test_table
+  },
   #
   NULL
 )

--- a/R/spec-result-send-query.R
+++ b/R/spec-result-send-query.R
@@ -107,7 +107,7 @@ spec_result_send_query <- list(
   },
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
-  send_query_immediate = function(con) with_remove_test_table({
+  send_query_immediate = function(con) with_remove_test_table(name = "test", {
       res <- expect_visible(dbSendQuery(con, trivial_query(), immediate = TRUE))
       expect_s4_class(res, "DBIResult")
       expect_error(dbGetRowsAffected(res), NA)

--- a/R/spec-result-send-query.R
+++ b/R/spec-result-send-query.R
@@ -107,14 +107,12 @@ spec_result_send_query <- list(
   },
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
-  send_query_immediate = function(con) {
-    with_remove_test_table({
+  send_query_immediate = function(con) with_remove_test_table({
       res <- expect_visible(dbSendQuery(con, trivial_query(), immediate = TRUE))
       expect_s4_class(res, "DBIResult")
       expect_error(dbGetRowsAffected(res), NA)
       dbClearResult(res)
-    })
-  },
+  }), # with_remove_test_table
   #
   NULL
 )

--- a/R/spec-result-send-query.R
+++ b/R/spec-result-send-query.R
@@ -108,10 +108,10 @@ spec_result_send_query <- list(
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
   send_query_immediate = function(con, table_name = "test") {
-      res <- expect_visible(dbSendQuery(con, trivial_query(), immediate = TRUE))
-      expect_s4_class(res, "DBIResult")
-      expect_error(dbGetRowsAffected(res), NA)
-      dbClearResult(res)
+    res <- expect_visible(dbSendQuery(con, trivial_query(), immediate = TRUE))
+    expect_s4_class(res, "DBIResult")
+    expect_error(dbGetRowsAffected(res), NA)
+    dbClearResult(res)
   },
   #
   NULL

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -98,9 +98,10 @@ spec_result_send_statement <- list(
   send_statement_params = function(ctx, con) {
     placeholder_funs <- get_placeholder_funs(ctx)
 
+    table_name <- "test"
     for (placeholder_fun in placeholder_funs) {
-      with_remove_test_table(name = "test", {
-        dbWriteTable(con, "test", data.frame(a = as.numeric(1:3)))
+      with_remove_test_table(name = table_name, {
+        dbWriteTable(con, table_name, data.frame(a = as.numeric(1:3)))
         placeholder <- placeholder_fun(1)
         query <- paste0("DELETE FROM test WHERE a > ", placeholder)
         values <- 1.5

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -10,7 +10,7 @@ spec_result_send_statement <- list(
 
   #' @return
   #' `dbSendStatement()` returns
-  send_statement_trivial = function(con) with_remove_test_table({
+  send_statement_trivial = function(con) with_remove_test_table(name = "test", {
       res <- expect_visible(dbSendStatement(con, trivial_statement()))
       #' an S4 object that inherits from [DBIResult-class].
       expect_s4_class(res, "DBIResult")
@@ -48,7 +48,7 @@ spec_result_send_statement <- list(
   },
 
   #' @section Specification:
-  send_statement_result_valid = function(con) with_remove_test_table({
+  send_statement_result_valid = function(con) with_remove_test_table(name = "test", {
       #' No warnings occur under normal conditions.
       expect_warning(res <- dbSendStatement(con, trivial_statement()), NA)
       #' When done, the DBIResult object must be cleared with a call to
@@ -68,7 +68,7 @@ spec_result_send_statement <- list(
   },
 
   #' If the backend supports only one open result set per connection,
-  send_statement_only_one_result_set = function(con) with_remove_test_table({
+  send_statement_only_one_result_set = function(con) with_remove_test_table(name = "test", {
       res1 <- dbSendStatement(con, trivial_statement())
       with_remove_test_table(name = "test2", {
         #' issuing a second query invalidates an already open result set
@@ -113,7 +113,7 @@ spec_result_send_statement <- list(
   },
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
-  send_statement_immediate = function(con) with_remove_test_table({
+  send_statement_immediate = function(con) with_remove_test_table(name = "test", {
       res <- expect_visible(dbSendStatement(con, trivial_statement(), immediate = TRUE))
       expect_s4_class(res, "DBIResult")
       expect_error(dbGetRowsAffected(res), NA)

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -11,15 +11,15 @@ spec_result_send_statement <- list(
   #' @return
   #' `dbSendStatement()` returns
   send_statement_trivial = function(con, table_name = "test") {
-      res <- expect_visible(dbSendStatement(con, trivial_statement()))
-      #' an S4 object that inherits from [DBIResult-class].
-      expect_s4_class(res, "DBIResult")
-      #' The result set can be used with [dbGetRowsAffected()] to
-      #' determine the number of rows affected by the query.
-      expect_error(dbGetRowsAffected(res), NA)
-      #' Once you have finished using a result, make sure to clear it
-      #' with [dbClearResult()].
-      dbClearResult(res)
+    res <- expect_visible(dbSendStatement(con, trivial_statement()))
+    #' an S4 object that inherits from [DBIResult-class].
+    expect_s4_class(res, "DBIResult")
+    #' The result set can be used with [dbGetRowsAffected()] to
+    #' determine the number of rows affected by the query.
+    expect_error(dbGetRowsAffected(res), NA)
+    #' Once you have finished using a result, make sure to clear it
+    #' with [dbClearResult()].
+    dbClearResult(res)
   },
 
   #' An error is raised when issuing a statement over a closed
@@ -49,11 +49,11 @@ spec_result_send_statement <- list(
 
   #' @section Specification:
   send_statement_result_valid = function(con, table_name = "test") {
-      #' No warnings occur under normal conditions.
-      expect_warning(res <- dbSendStatement(con, trivial_statement()), NA)
-      #' When done, the DBIResult object must be cleared with a call to
-      #' [dbClearResult()].
-      dbClearResult(res)
+    #' No warnings occur under normal conditions.
+    expect_warning(res <- dbSendStatement(con, trivial_statement()), NA)
+    #' When done, the DBIResult object must be cleared with a call to
+    #' [dbClearResult()].
+    dbClearResult(res)
   },
   #
   send_statement_stale_warning = function(ctx) {
@@ -69,17 +69,17 @@ spec_result_send_statement <- list(
 
   #' If the backend supports only one open result set per connection,
   send_statement_only_one_result_set = function(con, table_name = "test") {
-      res1 <- dbSendStatement(con, trivial_statement())
-      with_remove_test_table(name = "test2", {
-        #' issuing a second query invalidates an already open result set
-        #' and raises a warning.
-        expect_warning(res2 <- dbSendStatement(con, "CREATE TABLE test2 AS SELECT 1 AS a"))
-        expect_false(dbIsValid(res1))
-        #' The newly opened result set is valid
-        expect_true(dbIsValid(res2))
-        #' and must be cleared with `dbClearResult()`.
-        dbClearResult(res2)
-      })
+    res1 <- dbSendStatement(con, trivial_statement())
+    with_remove_test_table(name = "test2", {
+      #' issuing a second query invalidates an already open result set
+      #' and raises a warning.
+      expect_warning(res2 <- dbSendStatement(con, "CREATE TABLE test2 AS SELECT 1 AS a"))
+      expect_false(dbIsValid(res1))
+      #' The newly opened result set is valid
+      expect_true(dbIsValid(res2))
+      #' and must be cleared with `dbClearResult()`.
+      dbClearResult(res2)
+    })
   },
 
   #' @section Additional arguments:
@@ -114,10 +114,10 @@ spec_result_send_statement <- list(
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
   send_statement_immediate = function(con, table_name = "test") {
-      res <- expect_visible(dbSendStatement(con, trivial_statement(), immediate = TRUE))
-      expect_s4_class(res, "DBIResult")
-      expect_error(dbGetRowsAffected(res), NA)
-      dbClearResult(res)
+    res <- expect_visible(dbSendStatement(con, trivial_statement(), immediate = TRUE))
+    expect_s4_class(res, "DBIResult")
+    expect_error(dbGetRowsAffected(res), NA)
+    dbClearResult(res)
   },
   #
   NULL

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -10,8 +10,7 @@ spec_result_send_statement <- list(
 
   #' @return
   #' `dbSendStatement()` returns
-  send_statement_trivial = function(con) {
-    with_remove_test_table({
+  send_statement_trivial = function(con) with_remove_test_table({
       res <- expect_visible(dbSendStatement(con, trivial_statement()))
       #' an S4 object that inherits from [DBIResult-class].
       expect_s4_class(res, "DBIResult")
@@ -21,8 +20,7 @@ spec_result_send_statement <- list(
       #' Once you have finished using a result, make sure to clear it
       #' with [dbClearResult()].
       dbClearResult(res)
-    })
-  },
+  }), # with_remove_test_table
 
   #' An error is raised when issuing a statement over a closed
   send_statement_closed_connection = function(ctx, closed_con) {
@@ -50,15 +48,13 @@ spec_result_send_statement <- list(
   },
 
   #' @section Specification:
-  send_statement_result_valid = function(con) {
-    with_remove_test_table({
+  send_statement_result_valid = function(con) with_remove_test_table({
       #' No warnings occur under normal conditions.
       expect_warning(res <- dbSendStatement(con, trivial_statement()), NA)
       #' When done, the DBIResult object must be cleared with a call to
       #' [dbClearResult()].
       dbClearResult(res)
-    })
-  },
+  }), # with_remove_test_table
   #
   send_statement_stale_warning = function(ctx) {
     #' Failure to clear the result set leads to a warning
@@ -72,8 +68,7 @@ spec_result_send_statement <- list(
   },
 
   #' If the backend supports only one open result set per connection,
-  send_statement_only_one_result_set = function(con) {
-    with_remove_test_table({
+  send_statement_only_one_result_set = function(con) with_remove_test_table({
       res1 <- dbSendStatement(con, trivial_statement())
       with_remove_test_table(name = "test2", {
         #' issuing a second query invalidates an already open result set
@@ -85,8 +80,7 @@ spec_result_send_statement <- list(
         #' and must be cleared with `dbClearResult()`.
         dbClearResult(res2)
       })
-    })
-  },
+  }), # with_remove_test_table
 
   #' @section Additional arguments:
   #' The following arguments are not part of the `dbSendStatement()` generic
@@ -119,14 +113,12 @@ spec_result_send_statement <- list(
   },
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
-  send_statement_immediate = function(con) {
-    with_remove_test_table({
+  send_statement_immediate = function(con) with_remove_test_table({
       res <- expect_visible(dbSendStatement(con, trivial_statement(), immediate = TRUE))
       expect_s4_class(res, "DBIResult")
       expect_error(dbGetRowsAffected(res), NA)
       dbClearResult(res)
-    })
-  },
+  }), # with_remove_test_table
   #
   NULL
 )

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -10,7 +10,7 @@ spec_result_send_statement <- list(
 
   #' @return
   #' `dbSendStatement()` returns
-  send_statement_trivial = function(con) with_remove_test_table(name = "test", {
+  send_statement_trivial = function(con, table_name = "test") {
       res <- expect_visible(dbSendStatement(con, trivial_statement()))
       #' an S4 object that inherits from [DBIResult-class].
       expect_s4_class(res, "DBIResult")
@@ -20,7 +20,7 @@ spec_result_send_statement <- list(
       #' Once you have finished using a result, make sure to clear it
       #' with [dbClearResult()].
       dbClearResult(res)
-  }), # with_remove_test_table
+  },
 
   #' An error is raised when issuing a statement over a closed
   send_statement_closed_connection = function(ctx, closed_con) {
@@ -48,13 +48,13 @@ spec_result_send_statement <- list(
   },
 
   #' @section Specification:
-  send_statement_result_valid = function(con) with_remove_test_table(name = "test", {
+  send_statement_result_valid = function(con, table_name = "test") {
       #' No warnings occur under normal conditions.
       expect_warning(res <- dbSendStatement(con, trivial_statement()), NA)
       #' When done, the DBIResult object must be cleared with a call to
       #' [dbClearResult()].
       dbClearResult(res)
-  }), # with_remove_test_table
+  },
   #
   send_statement_stale_warning = function(ctx) {
     #' Failure to clear the result set leads to a warning
@@ -68,7 +68,7 @@ spec_result_send_statement <- list(
   },
 
   #' If the backend supports only one open result set per connection,
-  send_statement_only_one_result_set = function(con) with_remove_test_table(name = "test", {
+  send_statement_only_one_result_set = function(con, table_name = "test") {
       res1 <- dbSendStatement(con, trivial_statement())
       with_remove_test_table(name = "test2", {
         #' issuing a second query invalidates an already open result set
@@ -80,7 +80,7 @@ spec_result_send_statement <- list(
         #' and must be cleared with `dbClearResult()`.
         dbClearResult(res2)
       })
-  }), # with_remove_test_table
+  },
 
   #' @section Additional arguments:
   #' The following arguments are not part of the `dbSendStatement()` generic
@@ -113,12 +113,12 @@ spec_result_send_statement <- list(
   },
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
-  send_statement_immediate = function(con) with_remove_test_table(name = "test", {
+  send_statement_immediate = function(con, table_name = "test") {
       res <- expect_visible(dbSendStatement(con, trivial_statement(), immediate = TRUE))
       expect_s4_class(res, "DBIResult")
       expect_error(dbGetRowsAffected(res), NA)
       dbClearResult(res)
-  }), # with_remove_test_table
+  },
   #
   NULL
 )

--- a/R/spec-sql-append-table.R
+++ b/R/spec-sql-append-table.R
@@ -10,8 +10,7 @@ spec_sql_append_table <- list(
 
   #' @return
   #' `dbAppendTable()` returns a
-  append_table_return = function(con) {
-    with_remove_test_table({
+  append_table_return = function(con) with_remove_test_table({
       test_in <- trivial_df()
       dbCreateTable(con, "test", test_in)
       ret <- dbAppendTable(con, "test", test_in)
@@ -20,23 +19,19 @@ spec_sql_append_table <- list(
       expect_equal(length(ret), 1)
       #' numeric.
       expect_true(is.numeric(ret))
-    })
-  },
+  }), # with_remove_test_table
 
   #' If the table does not exist,
-  append_table_missing = function(con) {
-    with_remove_test_table({
+  append_table_missing = function(con) with_remove_test_table({
       expect_false(dbExistsTable(con, "test"))
 
       test_in <- trivial_df()
       expect_error(dbAppendTable(con, "test", data.frame(a = 2L)))
-    })
-  },
+  }), # with_remove_test_table
 
   #' or the data frame with the new data has different column names,
   #' an error is raised; the remote table remains unchanged.
-  append_table_append_incompatible = function(con) {
-    with_remove_test_table({
+  append_table_append_incompatible = function(con) with_remove_test_table({
       test_in <- trivial_df()
       dbCreateTable(con, "test", test_in)
       dbAppendTable(con, "test", test_in)
@@ -44,8 +39,7 @@ spec_sql_append_table <- list(
 
       test_out <- check_df(dbReadTable(con, "test"))
       expect_equal_df(test_out, test_in)
-    })
-  },
+  }), # with_remove_test_table
 
   #'
   #' An error is raised when calling this method for a closed
@@ -59,8 +53,7 @@ spec_sql_append_table <- list(
   },
 
   #' An error is also raised
-  append_table_error = function(con) {
-    with_remove_test_table({
+  append_table_error = function(con) with_remove_test_table({
       test_in <- data.frame(a = 1L)
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbAppendTable(con, NA, test_in))
@@ -74,10 +67,9 @@ spec_sql_append_table <- list(
       expect_error(dbAppendTable(con, "test", test_in, row.names = list(1L)))
       #' `NA`)
       expect_error(dbAppendTable(con, "test", test_in, row.names = NA))
-    })
 
-    #' also raise an error.
-  },
+      #' also raise an error.
+  }), # with_remove_test_table
 
   #'
   #' SQL keywords can be used freely in table names, column names, and data.
@@ -195,15 +187,13 @@ spec_sql_append_table <- list(
     )
   },
   #
-  append_roundtrip_64_bit_roundtrip = function(ctx, con) {
-    with_remove_test_table(name = table_name <- "test2", {
+  append_roundtrip_64_bit_roundtrip = function(ctx, con) with_remove_test_table(name = table_name <- "test2", {
       tbl_in <- data.frame(a = c(-1e14, 1e15))
       dbWriteTable(con, table_name, tbl_in, field.types = c(a = "BIGINT"))
       tbl_out <- dbReadTable(con, table_name)
       #'     - written to another table and read again unchanged
       test_table_roundtrip(use_append = TRUE, con, tbl_out, tbl_expected = tbl_out)
-    })
-  },
+  }), # with_remove_test_table
 
   #' - character (in both UTF-8
   append_roundtrip_character = function(con) {
@@ -424,8 +414,7 @@ spec_sql_append_table <- list(
   #'
   #'
   #' The `row.names` argument must be `NULL`, the default value.
-  append_table_row_names_false = function(con) {
-    with_remove_test_table(name = "mtcars", {
+  append_table_row_names_false = function(con) with_remove_test_table(name = "mtcars", {
       mtcars_in <- datasets::mtcars
       dbCreateTable(con, "mtcars", mtcars_in)
       dbAppendTable(con, "mtcars", mtcars_in)
@@ -433,12 +422,10 @@ spec_sql_append_table <- list(
 
       expect_false("row_names" %in% names(mtcars_out))
       expect_equal_df(mtcars_out, unrowname(mtcars_in))
-    })
-  },
+  }), # with_remove_test_table
 
   #' Row names are ignored.
-  append_table_row_names_ignore = function(con) {
-    with_remove_test_table(name = "mtcars", {
+  append_table_row_names_ignore = function(con) with_remove_test_table(name = "mtcars", {
       mtcars_in <- datasets::mtcars
       dbCreateTable(con, "mtcars", mtcars_in)
       dbAppendTable(con, "mtcars", mtcars_in, row.names = NULL)
@@ -446,11 +433,9 @@ spec_sql_append_table <- list(
 
       expect_false("row_names" %in% names(mtcars_out))
       expect_equal_df(mtcars_out, unrowname(mtcars_in))
-    })
-  },
+  }), # with_remove_test_table
   #
-  append_table_row_names_non_null = function(con) {
-    with_remove_test_table(name = "mtcars", {
+  append_table_row_names_non_null = function(con) with_remove_test_table(name = "mtcars", {
       #' All other values for the `row.names` argument
       mtcars_in <- datasets::mtcars
       dbCreateTable(con, "mtcars", mtcars_in)
@@ -461,10 +446,9 @@ spec_sql_append_table <- list(
       expect_error(dbAppendTable(con, "mtcars", mtcars_in, row.names = NA))
       #' and a string)
       expect_error(dbAppendTable(con, "mtcars", mtcars_in, row.names = "make_model"))
-    })
 
-    #' raise an error.
-  },
+      #' raise an error.
+  }), # with_remove_test_table
   #
   NULL
 )

--- a/R/spec-sql-append-table.R
+++ b/R/spec-sql-append-table.R
@@ -10,7 +10,7 @@ spec_sql_append_table <- list(
 
   #' @return
   #' `dbAppendTable()` returns a
-  append_table_return = function(con) with_remove_test_table(name = "test", {
+  append_table_return = function(con, table_name = "test") {
       test_in <- trivial_df()
       dbCreateTable(con, "test", test_in)
       ret <- dbAppendTable(con, "test", test_in)
@@ -19,19 +19,19 @@ spec_sql_append_table <- list(
       expect_equal(length(ret), 1)
       #' numeric.
       expect_true(is.numeric(ret))
-  }), # with_remove_test_table
+  },
 
   #' If the table does not exist,
-  append_table_missing = function(con) with_remove_test_table(name = "test", {
+  append_table_missing = function(con, table_name = "test") {
       expect_false(dbExistsTable(con, "test"))
 
       test_in <- trivial_df()
       expect_error(dbAppendTable(con, "test", data.frame(a = 2L)))
-  }), # with_remove_test_table
+  },
 
   #' or the data frame with the new data has different column names,
   #' an error is raised; the remote table remains unchanged.
-  append_table_append_incompatible = function(con) with_remove_test_table(name = "test", {
+  append_table_append_incompatible = function(con, table_name = "test") {
       test_in <- trivial_df()
       dbCreateTable(con, "test", test_in)
       dbAppendTable(con, "test", test_in)
@@ -39,7 +39,7 @@ spec_sql_append_table <- list(
 
       test_out <- check_df(dbReadTable(con, "test"))
       expect_equal_df(test_out, test_in)
-  }), # with_remove_test_table
+  },
 
   #'
   #' An error is raised when calling this method for a closed
@@ -53,7 +53,7 @@ spec_sql_append_table <- list(
   },
 
   #' An error is also raised
-  append_table_error = function(con) with_remove_test_table(name = "test", {
+  append_table_error = function(con, table_name = "test") {
       test_in <- data.frame(a = 1L)
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbAppendTable(con, NA, test_in))
@@ -69,7 +69,7 @@ spec_sql_append_table <- list(
       expect_error(dbAppendTable(con, "test", test_in, row.names = NA))
 
       #' also raise an error.
-  }), # with_remove_test_table
+  },
 
   #'
   #' SQL keywords can be used freely in table names, column names, and data.
@@ -414,7 +414,7 @@ spec_sql_append_table <- list(
   #'
   #'
   #' The `row.names` argument must be `NULL`, the default value.
-  append_table_row_names_false = function(con) with_remove_test_table(name = "mtcars", {
+  append_table_row_names_false = function(con, table_name = "mtcars") {
       mtcars_in <- datasets::mtcars
       dbCreateTable(con, "mtcars", mtcars_in)
       dbAppendTable(con, "mtcars", mtcars_in)
@@ -422,10 +422,10 @@ spec_sql_append_table <- list(
 
       expect_false("row_names" %in% names(mtcars_out))
       expect_equal_df(mtcars_out, unrowname(mtcars_in))
-  }), # with_remove_test_table
+  },
 
   #' Row names are ignored.
-  append_table_row_names_ignore = function(con) with_remove_test_table(name = "mtcars", {
+  append_table_row_names_ignore = function(con, table_name = "mtcars") {
       mtcars_in <- datasets::mtcars
       dbCreateTable(con, "mtcars", mtcars_in)
       dbAppendTable(con, "mtcars", mtcars_in, row.names = NULL)
@@ -433,9 +433,9 @@ spec_sql_append_table <- list(
 
       expect_false("row_names" %in% names(mtcars_out))
       expect_equal_df(mtcars_out, unrowname(mtcars_in))
-  }), # with_remove_test_table
+  },
   #
-  append_table_row_names_non_null = function(con) with_remove_test_table(name = "mtcars", {
+  append_table_row_names_non_null = function(con, table_name = "mtcars") {
       #' All other values for the `row.names` argument
       mtcars_in <- datasets::mtcars
       dbCreateTable(con, "mtcars", mtcars_in)
@@ -448,7 +448,7 @@ spec_sql_append_table <- list(
       expect_error(dbAppendTable(con, "mtcars", mtcars_in, row.names = "make_model"))
 
       #' raise an error.
-  }), # with_remove_test_table
+  },
   #
   NULL
 )

--- a/R/spec-sql-append-table.R
+++ b/R/spec-sql-append-table.R
@@ -10,7 +10,7 @@ spec_sql_append_table <- list(
 
   #' @return
   #' `dbAppendTable()` returns a
-  append_table_return = function(con) with_remove_test_table({
+  append_table_return = function(con) with_remove_test_table(name = "test", {
       test_in <- trivial_df()
       dbCreateTable(con, "test", test_in)
       ret <- dbAppendTable(con, "test", test_in)
@@ -22,7 +22,7 @@ spec_sql_append_table <- list(
   }), # with_remove_test_table
 
   #' If the table does not exist,
-  append_table_missing = function(con) with_remove_test_table({
+  append_table_missing = function(con) with_remove_test_table(name = "test", {
       expect_false(dbExistsTable(con, "test"))
 
       test_in <- trivial_df()
@@ -31,7 +31,7 @@ spec_sql_append_table <- list(
 
   #' or the data frame with the new data has different column names,
   #' an error is raised; the remote table remains unchanged.
-  append_table_append_incompatible = function(con) with_remove_test_table({
+  append_table_append_incompatible = function(con) with_remove_test_table(name = "test", {
       test_in <- trivial_df()
       dbCreateTable(con, "test", test_in)
       dbAppendTable(con, "test", test_in)
@@ -53,7 +53,7 @@ spec_sql_append_table <- list(
   },
 
   #' An error is also raised
-  append_table_error = function(con) with_remove_test_table({
+  append_table_error = function(con) with_remove_test_table(name = "test", {
       test_in <- data.frame(a = 1L)
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbAppendTable(con, NA, test_in))

--- a/R/spec-sql-append-table.R
+++ b/R/spec-sql-append-table.R
@@ -11,34 +11,34 @@ spec_sql_append_table <- list(
   #' @return
   #' `dbAppendTable()` returns a
   append_table_return = function(con, table_name = "test") {
-      test_in <- trivial_df()
-      dbCreateTable(con, "test", test_in)
-      ret <- dbAppendTable(con, "test", test_in)
+    test_in <- trivial_df()
+    dbCreateTable(con, "test", test_in)
+    ret <- dbAppendTable(con, "test", test_in)
 
-      #' scalar
-      expect_equal(length(ret), 1)
-      #' numeric.
-      expect_true(is.numeric(ret))
+    #' scalar
+    expect_equal(length(ret), 1)
+    #' numeric.
+    expect_true(is.numeric(ret))
   },
 
   #' If the table does not exist,
   append_table_missing = function(con, table_name = "test") {
-      expect_false(dbExistsTable(con, "test"))
+    expect_false(dbExistsTable(con, "test"))
 
-      test_in <- trivial_df()
-      expect_error(dbAppendTable(con, "test", data.frame(a = 2L)))
+    test_in <- trivial_df()
+    expect_error(dbAppendTable(con, "test", data.frame(a = 2L)))
   },
 
   #' or the data frame with the new data has different column names,
   #' an error is raised; the remote table remains unchanged.
   append_table_append_incompatible = function(con, table_name = "test") {
-      test_in <- trivial_df()
-      dbCreateTable(con, "test", test_in)
-      dbAppendTable(con, "test", test_in)
-      expect_error(dbAppendTable(con, "test", data.frame(b = 2L), append = TRUE))
+    test_in <- trivial_df()
+    dbCreateTable(con, "test", test_in)
+    dbAppendTable(con, "test", test_in)
+    expect_error(dbAppendTable(con, "test", data.frame(b = 2L), append = TRUE))
 
-      test_out <- check_df(dbReadTable(con, "test"))
-      expect_equal_df(test_out, test_in)
+    test_out <- check_df(dbReadTable(con, "test"))
+    expect_equal_df(test_out, test_in)
   },
 
   #'
@@ -54,21 +54,21 @@ spec_sql_append_table <- list(
 
   #' An error is also raised
   append_table_error = function(con, table_name = "test") {
-      test_in <- data.frame(a = 1L)
-      #' if `name` cannot be processed with [dbQuoteIdentifier()]
-      expect_error(dbAppendTable(con, NA, test_in))
-      #' or if this results in a non-scalar.
-      expect_error(dbAppendTable(con, c("test", "test"), test_in))
+    test_in <- data.frame(a = 1L)
+    #' if `name` cannot be processed with [dbQuoteIdentifier()]
+    expect_error(dbAppendTable(con, NA, test_in))
+    #' or if this results in a non-scalar.
+    expect_error(dbAppendTable(con, c("test", "test"), test_in))
 
-      #' Invalid values for the `row.names` argument
-      #' (non-scalars,
-      expect_error(dbAppendTable(con, "test", test_in, row.names = letters))
-      #' unsupported data types,
-      expect_error(dbAppendTable(con, "test", test_in, row.names = list(1L)))
-      #' `NA`)
-      expect_error(dbAppendTable(con, "test", test_in, row.names = NA))
+    #' Invalid values for the `row.names` argument
+    #' (non-scalars,
+    expect_error(dbAppendTable(con, "test", test_in, row.names = letters))
+    #' unsupported data types,
+    expect_error(dbAppendTable(con, "test", test_in, row.names = list(1L)))
+    #' `NA`)
+    expect_error(dbAppendTable(con, "test", test_in, row.names = NA))
 
-      #' also raise an error.
+    #' also raise an error.
   },
 
   #'
@@ -188,11 +188,11 @@ spec_sql_append_table <- list(
   },
   #
   append_roundtrip_64_bit_roundtrip = function(con, table_name) {
-      tbl_in <- data.frame(a = c(-1e14, 1e15))
-      dbWriteTable(con, table_name, tbl_in, field.types = c(a = "BIGINT"))
-      tbl_out <- dbReadTable(con, table_name)
-      #'     - written to another table and read again unchanged
-      test_table_roundtrip(use_append = TRUE, con, tbl_out, tbl_expected = tbl_out)
+    tbl_in <- data.frame(a = c(-1e14, 1e15))
+    dbWriteTable(con, table_name, tbl_in, field.types = c(a = "BIGINT"))
+    tbl_out <- dbReadTable(con, table_name)
+    #'     - written to another table and read again unchanged
+    test_table_roundtrip(use_append = TRUE, con, tbl_out, tbl_expected = tbl_out)
   },
 
   #' - character (in both UTF-8
@@ -415,39 +415,39 @@ spec_sql_append_table <- list(
   #'
   #' The `row.names` argument must be `NULL`, the default value.
   append_table_row_names_false = function(con, table_name = "mtcars") {
-      mtcars_in <- datasets::mtcars
-      dbCreateTable(con, "mtcars", mtcars_in)
-      dbAppendTable(con, "mtcars", mtcars_in)
-      mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
+    mtcars_in <- datasets::mtcars
+    dbCreateTable(con, "mtcars", mtcars_in)
+    dbAppendTable(con, "mtcars", mtcars_in)
+    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
 
-      expect_false("row_names" %in% names(mtcars_out))
-      expect_equal_df(mtcars_out, unrowname(mtcars_in))
+    expect_false("row_names" %in% names(mtcars_out))
+    expect_equal_df(mtcars_out, unrowname(mtcars_in))
   },
 
   #' Row names are ignored.
   append_table_row_names_ignore = function(con, table_name = "mtcars") {
-      mtcars_in <- datasets::mtcars
-      dbCreateTable(con, "mtcars", mtcars_in)
-      dbAppendTable(con, "mtcars", mtcars_in, row.names = NULL)
-      mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
+    mtcars_in <- datasets::mtcars
+    dbCreateTable(con, "mtcars", mtcars_in)
+    dbAppendTable(con, "mtcars", mtcars_in, row.names = NULL)
+    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
 
-      expect_false("row_names" %in% names(mtcars_out))
-      expect_equal_df(mtcars_out, unrowname(mtcars_in))
+    expect_false("row_names" %in% names(mtcars_out))
+    expect_equal_df(mtcars_out, unrowname(mtcars_in))
   },
   #
   append_table_row_names_non_null = function(con, table_name = "mtcars") {
-      #' All other values for the `row.names` argument
-      mtcars_in <- datasets::mtcars
-      dbCreateTable(con, "mtcars", mtcars_in)
+    #' All other values for the `row.names` argument
+    mtcars_in <- datasets::mtcars
+    dbCreateTable(con, "mtcars", mtcars_in)
 
-      #' (in particular `TRUE`,
-      expect_error(dbAppendTable(con, "mtcars", mtcars_in, row.names = TRUE))
-      #' `NA`,
-      expect_error(dbAppendTable(con, "mtcars", mtcars_in, row.names = NA))
-      #' and a string)
-      expect_error(dbAppendTable(con, "mtcars", mtcars_in, row.names = "make_model"))
+    #' (in particular `TRUE`,
+    expect_error(dbAppendTable(con, "mtcars", mtcars_in, row.names = TRUE))
+    #' `NA`,
+    expect_error(dbAppendTable(con, "mtcars", mtcars_in, row.names = NA))
+    #' and a string)
+    expect_error(dbAppendTable(con, "mtcars", mtcars_in, row.names = "make_model"))
 
-      #' raise an error.
+    #' raise an error.
   },
   #
   NULL

--- a/R/spec-sql-append-table.R
+++ b/R/spec-sql-append-table.R
@@ -12,8 +12,8 @@ spec_sql_append_table <- list(
   #' `dbAppendTable()` returns a
   append_table_return = function(con, table_name = "test") {
     test_in <- trivial_df()
-    dbCreateTable(con, "test", test_in)
-    ret <- dbAppendTable(con, "test", test_in)
+    dbCreateTable(con, table_name, test_in)
+    ret <- dbAppendTable(con, table_name, test_in)
 
     #' scalar
     expect_equal(length(ret), 1)
@@ -23,21 +23,21 @@ spec_sql_append_table <- list(
 
   #' If the table does not exist,
   append_table_missing = function(con, table_name = "test") {
-    expect_false(dbExistsTable(con, "test"))
+    expect_false(dbExistsTable(con, table_name))
 
     test_in <- trivial_df()
-    expect_error(dbAppendTable(con, "test", data.frame(a = 2L)))
+    expect_error(dbAppendTable(con, table_name, data.frame(a = 2L)))
   },
 
   #' or the data frame with the new data has different column names,
   #' an error is raised; the remote table remains unchanged.
   append_table_append_incompatible = function(con, table_name = "test") {
     test_in <- trivial_df()
-    dbCreateTable(con, "test", test_in)
-    dbAppendTable(con, "test", test_in)
-    expect_error(dbAppendTable(con, "test", data.frame(b = 2L), append = TRUE))
+    dbCreateTable(con, table_name, test_in)
+    dbAppendTable(con, table_name, test_in)
+    expect_error(dbAppendTable(con, table_name, data.frame(b = 2L), append = TRUE))
 
-    test_out <- check_df(dbReadTable(con, "test"))
+    test_out <- check_df(dbReadTable(con, table_name))
     expect_equal_df(test_out, test_in)
   },
 

--- a/R/spec-sql-append-table.R
+++ b/R/spec-sql-append-table.R
@@ -187,13 +187,13 @@ spec_sql_append_table <- list(
     )
   },
   #
-  append_roundtrip_64_bit_roundtrip = function(ctx, con) with_remove_test_table(name = table_name <- "test2", {
+  append_roundtrip_64_bit_roundtrip = function(con, table_name) {
       tbl_in <- data.frame(a = c(-1e14, 1e15))
       dbWriteTable(con, table_name, tbl_in, field.types = c(a = "BIGINT"))
       tbl_out <- dbReadTable(con, table_name)
       #'     - written to another table and read again unchanged
       test_table_roundtrip(use_append = TRUE, con, tbl_out, tbl_expected = tbl_out)
-  }), # with_remove_test_table
+  },
 
   #' - character (in both UTF-8
   append_roundtrip_character = function(con) {

--- a/R/spec-sql-create-table.R
+++ b/R/spec-sql-create-table.R
@@ -11,18 +11,18 @@ spec_sql_create_table <- list(
   #' @return
   #' `dbCreateTable()` returns `TRUE`, invisibly.
   create_table_return = function(con, table_name = "test") {
-    expect_invisible_true(dbCreateTable(con, "test", trivial_df()))
+    expect_invisible_true(dbCreateTable(con, table_name, trivial_df()))
   },
 
   #' If the table exists, an error is raised; the remote table remains unchanged.
   create_table_overwrite = function(con, table_name = "test") {
     test_in <- trivial_df()
 
-    dbCreateTable(con, "test", test_in)
-    dbAppendTable(con, "test", test_in)
-    expect_error(dbCreateTable(con, "test", data.frame(b = 1L)))
+    dbCreateTable(con, table_name, test_in)
+    dbAppendTable(con, table_name, test_in)
+    expect_error(dbCreateTable(con, table_name, data.frame(b = 1L)))
 
-    test_out <- check_df(dbReadTable(con, "test"))
+    test_out <- check_df(dbReadTable(con, table_name))
     expect_equal_df(test_out, test_in)
   },
 
@@ -43,24 +43,24 @@ spec_sql_create_table <- list(
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbCreateTable(con, NA, test_in))
     #' or if this results in a non-scalar.
-    expect_error(dbCreateTable(con, c("test", "test"), test_in))
+    expect_error(dbCreateTable(con, c(table_name, table_name), test_in))
 
     #' Invalid values for the `row.names` and `temporary` arguments
     #' (non-scalars,
-    expect_error(dbCreateTable(con, "test", test_in, row.names = letters))
-    expect_error(dbCreateTable(con, "test", test_in, temporary = c(TRUE, FALSE)))
+    expect_error(dbCreateTable(con, table_name, test_in, row.names = letters))
+    expect_error(dbCreateTable(con, table_name, test_in, temporary = c(TRUE, FALSE)))
     #' unsupported data types,
-    expect_error(dbCreateTable(con, "test", test_in, row.names = list(1L)))
-    expect_error(dbCreateTable(con, "test", fields = 1L))
-    expect_error(dbCreateTable(con, "test", test_in, temporary = 1L))
+    expect_error(dbCreateTable(con, table_name, test_in, row.names = list(1L)))
+    expect_error(dbCreateTable(con, table_name, fields = 1L))
+    expect_error(dbCreateTable(con, table_name, test_in, temporary = 1L))
     #' `NA`,
-    expect_error(dbCreateTable(con, "test", test_in, row.names = NA))
-    expect_error(dbCreateTable(con, "test", fields = NA))
-    expect_error(dbCreateTable(con, "test", test_in, temporary = NA))
+    expect_error(dbCreateTable(con, table_name, test_in, row.names = NA))
+    expect_error(dbCreateTable(con, table_name, fields = NA))
+    expect_error(dbCreateTable(con, table_name, test_in, temporary = NA))
     #' incompatible values,
-    expect_error(dbCreateTable(con, "test", test_in, fields = letters))
+    expect_error(dbCreateTable(con, table_name, test_in, fields = letters))
     #' duplicate names)
-    expect_error(dbCreateTable(con, "test", fields = c(a = "INTEGER", a = "INTEGER")))
+    expect_error(dbCreateTable(con, table_name, fields = c(a = "INTEGER", a = "INTEGER")))
 
     #' also raise an error.
   },

--- a/R/spec-sql-create-table.R
+++ b/R/spec-sql-create-table.R
@@ -10,15 +10,12 @@ spec_sql_create_table <- list(
 
   #' @return
   #' `dbCreateTable()` returns `TRUE`, invisibly.
-  create_table_return = function(con) {
-    with_remove_test_table({
+  create_table_return = function(con) with_remove_test_table({
       expect_invisible_true(dbCreateTable(con, "test", trivial_df()))
-    })
-  },
+  }), # with_remove_test_table
 
   #' If the table exists, an error is raised; the remote table remains unchanged.
-  create_table_overwrite = function(con) {
-    with_remove_test_table({
+  create_table_overwrite = function(con) with_remove_test_table({
       test_in <- trivial_df()
 
       dbCreateTable(con, "test", test_in)
@@ -27,8 +24,7 @@ spec_sql_create_table <- list(
 
       test_out <- check_df(dbReadTable(con, "test"))
       expect_equal_df(test_out, test_in)
-    })
-  },
+  }), # with_remove_test_table
 
   #'
   #' An error is raised when calling this method for a closed
@@ -42,8 +38,7 @@ spec_sql_create_table <- list(
   },
 
   #' An error is also raised
-  create_table_error = function(ctx, con) {
-    with_remove_test_table({
+  create_table_error = function(ctx, con) with_remove_test_table({
       test_in <- data.frame(a = 1L)
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbCreateTable(con, NA, test_in))
@@ -66,10 +61,9 @@ spec_sql_create_table <- list(
       expect_error(dbCreateTable(con, "test", test_in, fields = letters))
       #' duplicate names)
       expect_error(dbCreateTable(con, "test", fields = c(a = "INTEGER", a = "INTEGER")))
-    })
 
-    #' also raise an error.
-  },
+      #' also raise an error.
+  }), # with_remove_test_table
 
   #' @section Additional arguments:
   #' The following arguments are not part of the `dbCreateTable()` generic
@@ -113,8 +107,7 @@ spec_sql_create_table <- list(
   #'
   #' If the `temporary` argument is `TRUE`, the table is not available in a
   #' second connection and is gone after reconnecting.
-  create_temporary_table = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  create_temporary_table = function(ctx, con) with_remove_test_table(name = "iris", {
       #' Not all backends support this argument.
       if (!isTRUE(ctx$tweaks$temporary_tables)) {
         skip("tweak: temporary_tables")
@@ -127,8 +120,7 @@ spec_sql_create_table <- list(
 
       con2 <- local_connection(ctx)
       expect_error(dbReadTable(con2, "iris"))
-    })
-  },
+  }), # with_remove_test_table
   # second stage
   create_temporary_table = function(con) {
     expect_error(dbReadTable(con, "iris"))
@@ -146,12 +138,10 @@ spec_sql_create_table <- list(
     expect_equal_df(dbReadTable(con2, "iris"), iris[0, , drop = FALSE])
   },
   # second stage
-  create_table_visible_in_other_connection = function(con) {
-    with_remove_test_table(name = "iris", {
+  create_table_visible_in_other_connection = function(con) with_remove_test_table(name = "iris", {
       #' and after reconnecting to the database.
       expect_equal_df(check_df(dbReadTable(con, "iris")), iris[0, , drop = FALSE])
-    })
-  },
+  }), # with_remove_test_table
 
   #'
   #' SQL keywords can be used freely in table names, column names, and data.
@@ -193,30 +183,25 @@ spec_sql_create_table <- list(
 
   #'
   #' The `row.names` argument must be missing
-  create_table_row_names_default = function(ctx, con) {
-    with_remove_test_table(name = "mtcars", {
+  create_table_row_names_default = function(ctx, con) with_remove_test_table(name = "mtcars", {
       mtcars_in <- datasets::mtcars
       dbCreateTable(con, "mtcars", mtcars_in)
       mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
 
       expect_false("row_names" %in% names(mtcars_out))
       expect_equal_df(mtcars_out, unrowname(mtcars_in)[0, , drop = FALSE])
-    })
-  },
+  }), # with_remove_test_table
   #' or `NULL`, the default value.
-  create_table_row_names_null = function(ctx, con) {
-    with_remove_test_table(name = "mtcars", {
+  create_table_row_names_null = function(ctx, con) with_remove_test_table(name = "mtcars", {
       mtcars_in <- datasets::mtcars
       dbCreateTable(con, "mtcars", mtcars_in, row.names = NULL)
       mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = NULL))
 
       expect_false("row_names" %in% names(mtcars_out))
       expect_equal_df(mtcars_out, unrowname(mtcars_in)[0, , drop = FALSE])
-    })
-  },
+  }), # with_remove_test_table
   #
-  create_table_row_names_non_null = function(ctx, con) {
-    with_remove_test_table(name = "mtcars", {
+  create_table_row_names_non_null = function(ctx, con) with_remove_test_table(name = "mtcars", {
       #' All other values for the `row.names` argument
       mtcars_in <- datasets::mtcars
 
@@ -227,8 +212,7 @@ spec_sql_create_table <- list(
       #' and a string)
       expect_error(dbCreateTable(con, "mtcars", mtcars_in, row.names = "make_model"))
       #' raise an error.
-    })
-  },
+  }), # with_remove_test_table
   #
   NULL
 )

--- a/R/spec-sql-create-table.R
+++ b/R/spec-sql-create-table.R
@@ -10,12 +10,12 @@ spec_sql_create_table <- list(
 
   #' @return
   #' `dbCreateTable()` returns `TRUE`, invisibly.
-  create_table_return = function(con) with_remove_test_table({
+  create_table_return = function(con) with_remove_test_table(name = "test", {
       expect_invisible_true(dbCreateTable(con, "test", trivial_df()))
   }), # with_remove_test_table
 
   #' If the table exists, an error is raised; the remote table remains unchanged.
-  create_table_overwrite = function(con) with_remove_test_table({
+  create_table_overwrite = function(con) with_remove_test_table(name = "test", {
       test_in <- trivial_df()
 
       dbCreateTable(con, "test", test_in)
@@ -38,7 +38,7 @@ spec_sql_create_table <- list(
   },
 
   #' An error is also raised
-  create_table_error = function(ctx, con) with_remove_test_table({
+  create_table_error = function(ctx, con) with_remove_test_table(name = "test", {
       test_in <- data.frame(a = 1L)
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbCreateTable(con, NA, test_in))

--- a/R/spec-sql-create-table.R
+++ b/R/spec-sql-create-table.R
@@ -11,19 +11,19 @@ spec_sql_create_table <- list(
   #' @return
   #' `dbCreateTable()` returns `TRUE`, invisibly.
   create_table_return = function(con, table_name = "test") {
-      expect_invisible_true(dbCreateTable(con, "test", trivial_df()))
+    expect_invisible_true(dbCreateTable(con, "test", trivial_df()))
   },
 
   #' If the table exists, an error is raised; the remote table remains unchanged.
   create_table_overwrite = function(con, table_name = "test") {
-      test_in <- trivial_df()
+    test_in <- trivial_df()
 
-      dbCreateTable(con, "test", test_in)
-      dbAppendTable(con, "test", test_in)
-      expect_error(dbCreateTable(con, "test", data.frame(b = 1L)))
+    dbCreateTable(con, "test", test_in)
+    dbAppendTable(con, "test", test_in)
+    expect_error(dbCreateTable(con, "test", data.frame(b = 1L)))
 
-      test_out <- check_df(dbReadTable(con, "test"))
-      expect_equal_df(test_out, test_in)
+    test_out <- check_df(dbReadTable(con, "test"))
+    expect_equal_df(test_out, test_in)
   },
 
   #'
@@ -39,30 +39,30 @@ spec_sql_create_table <- list(
 
   #' An error is also raised
   create_table_error = function(ctx, con, table_name = "test") {
-      test_in <- data.frame(a = 1L)
-      #' if `name` cannot be processed with [dbQuoteIdentifier()]
-      expect_error(dbCreateTable(con, NA, test_in))
-      #' or if this results in a non-scalar.
-      expect_error(dbCreateTable(con, c("test", "test"), test_in))
+    test_in <- data.frame(a = 1L)
+    #' if `name` cannot be processed with [dbQuoteIdentifier()]
+    expect_error(dbCreateTable(con, NA, test_in))
+    #' or if this results in a non-scalar.
+    expect_error(dbCreateTable(con, c("test", "test"), test_in))
 
-      #' Invalid values for the `row.names` and `temporary` arguments
-      #' (non-scalars,
-      expect_error(dbCreateTable(con, "test", test_in, row.names = letters))
-      expect_error(dbCreateTable(con, "test", test_in, temporary = c(TRUE, FALSE)))
-      #' unsupported data types,
-      expect_error(dbCreateTable(con, "test", test_in, row.names = list(1L)))
-      expect_error(dbCreateTable(con, "test", fields = 1L))
-      expect_error(dbCreateTable(con, "test", test_in, temporary = 1L))
-      #' `NA`,
-      expect_error(dbCreateTable(con, "test", test_in, row.names = NA))
-      expect_error(dbCreateTable(con, "test", fields = NA))
-      expect_error(dbCreateTable(con, "test", test_in, temporary = NA))
-      #' incompatible values,
-      expect_error(dbCreateTable(con, "test", test_in, fields = letters))
-      #' duplicate names)
-      expect_error(dbCreateTable(con, "test", fields = c(a = "INTEGER", a = "INTEGER")))
+    #' Invalid values for the `row.names` and `temporary` arguments
+    #' (non-scalars,
+    expect_error(dbCreateTable(con, "test", test_in, row.names = letters))
+    expect_error(dbCreateTable(con, "test", test_in, temporary = c(TRUE, FALSE)))
+    #' unsupported data types,
+    expect_error(dbCreateTable(con, "test", test_in, row.names = list(1L)))
+    expect_error(dbCreateTable(con, "test", fields = 1L))
+    expect_error(dbCreateTable(con, "test", test_in, temporary = 1L))
+    #' `NA`,
+    expect_error(dbCreateTable(con, "test", test_in, row.names = NA))
+    expect_error(dbCreateTable(con, "test", fields = NA))
+    expect_error(dbCreateTable(con, "test", test_in, temporary = NA))
+    #' incompatible values,
+    expect_error(dbCreateTable(con, "test", test_in, fields = letters))
+    #' duplicate names)
+    expect_error(dbCreateTable(con, "test", fields = c(a = "INTEGER", a = "INTEGER")))
 
-      #' also raise an error.
+    #' also raise an error.
   },
 
   #' @section Additional arguments:
@@ -108,18 +108,18 @@ spec_sql_create_table <- list(
   #' If the `temporary` argument is `TRUE`, the table is not available in a
   #' second connection and is gone after reconnecting.
   create_temporary_table = function(ctx, con, table_name = "iris") {
-      #' Not all backends support this argument.
-      if (!isTRUE(ctx$tweaks$temporary_tables)) {
-        skip("tweak: temporary_tables")
-      }
+    #' Not all backends support this argument.
+    if (!isTRUE(ctx$tweaks$temporary_tables)) {
+      skip("tweak: temporary_tables")
+    }
 
-      iris <- get_iris(ctx)[1:30, ]
-      dbCreateTable(con, "iris", iris, temporary = TRUE)
-      iris_out <- check_df(dbReadTable(con, "iris"))
-      expect_equal_df(iris_out, iris[0, , drop = FALSE])
+    iris <- get_iris(ctx)[1:30, ]
+    dbCreateTable(con, "iris", iris, temporary = TRUE)
+    iris_out <- check_df(dbReadTable(con, "iris"))
+    expect_equal_df(iris_out, iris[0, , drop = FALSE])
 
-      con2 <- local_connection(ctx)
-      expect_error(dbReadTable(con2, "iris"))
+    con2 <- local_connection(ctx)
+    expect_error(dbReadTable(con2, "iris"))
   },
   # second stage
   create_temporary_table = function(con) {
@@ -139,8 +139,8 @@ spec_sql_create_table <- list(
   },
   # second stage
   create_table_visible_in_other_connection = function(con, table_name = "iris") {
-      #' and after reconnecting to the database.
-      expect_equal_df(check_df(dbReadTable(con, "iris")), iris[0, , drop = FALSE])
+    #' and after reconnecting to the database.
+    expect_equal_df(check_df(dbReadTable(con, "iris")), iris[0, , drop = FALSE])
   },
 
   #'
@@ -184,34 +184,34 @@ spec_sql_create_table <- list(
   #'
   #' The `row.names` argument must be missing
   create_table_row_names_default = function(ctx, con, table_name = "mtcars") {
-      mtcars_in <- datasets::mtcars
-      dbCreateTable(con, "mtcars", mtcars_in)
-      mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
+    mtcars_in <- datasets::mtcars
+    dbCreateTable(con, "mtcars", mtcars_in)
+    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
 
-      expect_false("row_names" %in% names(mtcars_out))
-      expect_equal_df(mtcars_out, unrowname(mtcars_in)[0, , drop = FALSE])
+    expect_false("row_names" %in% names(mtcars_out))
+    expect_equal_df(mtcars_out, unrowname(mtcars_in)[0, , drop = FALSE])
   },
   #' or `NULL`, the default value.
   create_table_row_names_null = function(ctx, con, table_name = "mtcars") {
-      mtcars_in <- datasets::mtcars
-      dbCreateTable(con, "mtcars", mtcars_in, row.names = NULL)
-      mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = NULL))
+    mtcars_in <- datasets::mtcars
+    dbCreateTable(con, "mtcars", mtcars_in, row.names = NULL)
+    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = NULL))
 
-      expect_false("row_names" %in% names(mtcars_out))
-      expect_equal_df(mtcars_out, unrowname(mtcars_in)[0, , drop = FALSE])
+    expect_false("row_names" %in% names(mtcars_out))
+    expect_equal_df(mtcars_out, unrowname(mtcars_in)[0, , drop = FALSE])
   },
   #
   create_table_row_names_non_null = function(ctx, con, table_name = "mtcars") {
-      #' All other values for the `row.names` argument
-      mtcars_in <- datasets::mtcars
+    #' All other values for the `row.names` argument
+    mtcars_in <- datasets::mtcars
 
-      #' (in particular `TRUE`,
-      expect_error(dbCreateTable(con, "mtcars", mtcars_in, row.names = TRUE))
-      #' `NA`,
-      expect_error(dbCreateTable(con, "mtcars", mtcars_in, row.names = NA))
-      #' and a string)
-      expect_error(dbCreateTable(con, "mtcars", mtcars_in, row.names = "make_model"))
-      #' raise an error.
+    #' (in particular `TRUE`,
+    expect_error(dbCreateTable(con, "mtcars", mtcars_in, row.names = TRUE))
+    #' `NA`,
+    expect_error(dbCreateTable(con, "mtcars", mtcars_in, row.names = NA))
+    #' and a string)
+    expect_error(dbCreateTable(con, "mtcars", mtcars_in, row.names = "make_model"))
+    #' raise an error.
   },
   #
   NULL

--- a/R/spec-sql-create-table.R
+++ b/R/spec-sql-create-table.R
@@ -10,12 +10,12 @@ spec_sql_create_table <- list(
 
   #' @return
   #' `dbCreateTable()` returns `TRUE`, invisibly.
-  create_table_return = function(con) with_remove_test_table(name = "test", {
+  create_table_return = function(con, table_name = "test") {
       expect_invisible_true(dbCreateTable(con, "test", trivial_df()))
-  }), # with_remove_test_table
+  },
 
   #' If the table exists, an error is raised; the remote table remains unchanged.
-  create_table_overwrite = function(con) with_remove_test_table(name = "test", {
+  create_table_overwrite = function(con, table_name = "test") {
       test_in <- trivial_df()
 
       dbCreateTable(con, "test", test_in)
@@ -24,7 +24,7 @@ spec_sql_create_table <- list(
 
       test_out <- check_df(dbReadTable(con, "test"))
       expect_equal_df(test_out, test_in)
-  }), # with_remove_test_table
+  },
 
   #'
   #' An error is raised when calling this method for a closed
@@ -38,7 +38,7 @@ spec_sql_create_table <- list(
   },
 
   #' An error is also raised
-  create_table_error = function(ctx, con) with_remove_test_table(name = "test", {
+  create_table_error = function(ctx, con, table_name = "test") {
       test_in <- data.frame(a = 1L)
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbCreateTable(con, NA, test_in))
@@ -63,7 +63,7 @@ spec_sql_create_table <- list(
       expect_error(dbCreateTable(con, "test", fields = c(a = "INTEGER", a = "INTEGER")))
 
       #' also raise an error.
-  }), # with_remove_test_table
+  },
 
   #' @section Additional arguments:
   #' The following arguments are not part of the `dbCreateTable()` generic
@@ -107,7 +107,7 @@ spec_sql_create_table <- list(
   #'
   #' If the `temporary` argument is `TRUE`, the table is not available in a
   #' second connection and is gone after reconnecting.
-  create_temporary_table = function(ctx, con) with_remove_test_table(name = "iris", {
+  create_temporary_table = function(ctx, con, table_name = "iris") {
       #' Not all backends support this argument.
       if (!isTRUE(ctx$tweaks$temporary_tables)) {
         skip("tweak: temporary_tables")
@@ -120,7 +120,7 @@ spec_sql_create_table <- list(
 
       con2 <- local_connection(ctx)
       expect_error(dbReadTable(con2, "iris"))
-  }), # with_remove_test_table
+  },
   # second stage
   create_temporary_table = function(con) {
     expect_error(dbReadTable(con, "iris"))
@@ -138,10 +138,10 @@ spec_sql_create_table <- list(
     expect_equal_df(dbReadTable(con2, "iris"), iris[0, , drop = FALSE])
   },
   # second stage
-  create_table_visible_in_other_connection = function(con) with_remove_test_table(name = "iris", {
+  create_table_visible_in_other_connection = function(con, table_name = "iris") {
       #' and after reconnecting to the database.
       expect_equal_df(check_df(dbReadTable(con, "iris")), iris[0, , drop = FALSE])
-  }), # with_remove_test_table
+  },
 
   #'
   #' SQL keywords can be used freely in table names, column names, and data.
@@ -183,25 +183,25 @@ spec_sql_create_table <- list(
 
   #'
   #' The `row.names` argument must be missing
-  create_table_row_names_default = function(ctx, con) with_remove_test_table(name = "mtcars", {
+  create_table_row_names_default = function(ctx, con, table_name = "mtcars") {
       mtcars_in <- datasets::mtcars
       dbCreateTable(con, "mtcars", mtcars_in)
       mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
 
       expect_false("row_names" %in% names(mtcars_out))
       expect_equal_df(mtcars_out, unrowname(mtcars_in)[0, , drop = FALSE])
-  }), # with_remove_test_table
+  },
   #' or `NULL`, the default value.
-  create_table_row_names_null = function(ctx, con) with_remove_test_table(name = "mtcars", {
+  create_table_row_names_null = function(ctx, con, table_name = "mtcars") {
       mtcars_in <- datasets::mtcars
       dbCreateTable(con, "mtcars", mtcars_in, row.names = NULL)
       mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = NULL))
 
       expect_false("row_names" %in% names(mtcars_out))
       expect_equal_df(mtcars_out, unrowname(mtcars_in)[0, , drop = FALSE])
-  }), # with_remove_test_table
+  },
   #
-  create_table_row_names_non_null = function(ctx, con) with_remove_test_table(name = "mtcars", {
+  create_table_row_names_non_null = function(ctx, con, table_name = "mtcars") {
       #' All other values for the `row.names` argument
       mtcars_in <- datasets::mtcars
 
@@ -212,7 +212,7 @@ spec_sql_create_table <- list(
       #' and a string)
       expect_error(dbCreateTable(con, "mtcars", mtcars_in, row.names = "make_model"))
       #' raise an error.
-  }), # with_remove_test_table
+  },
   #
   NULL
 )

--- a/R/spec-sql-exists-table.R
+++ b/R/spec-sql-exists-table.R
@@ -12,19 +12,19 @@ spec_sql_exists_table <- list(
   #' `dbExistsTable()` returns a logical scalar, `TRUE` if the table or view
   #' specified by the `name` argument exists, `FALSE` otherwise.
   exists_table = function(ctx, con, table_name = "iris") {
-      expect_false(expect_visible(dbExistsTable(con, "iris")))
-      iris <- get_iris(ctx)
-      dbWriteTable(con, "iris", iris)
+    expect_false(expect_visible(dbExistsTable(con, "iris")))
+    iris <- get_iris(ctx)
+    dbWriteTable(con, "iris", iris)
 
-      expect_true(expect_visible(dbExistsTable(con, "iris")))
+    expect_true(expect_visible(dbExistsTable(con, "iris")))
 
-      expect_false(expect_visible(dbExistsTable(con, "test")))
+    expect_false(expect_visible(dbExistsTable(con, "test")))
 
-      #' This includes temporary tables if supported by the database.
-      if (isTRUE(ctx$tweaks$temporary_tables)) {
-        dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
-        expect_true(expect_visible(dbExistsTable(con, "test")))
-      }
+    #' This includes temporary tables if supported by the database.
+    if (isTRUE(ctx$tweaks$temporary_tables)) {
+      dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
+      expect_true(expect_visible(dbExistsTable(con, "test")))
+    }
   },
   # second stage
   exists_table = function(ctx, con) {
@@ -44,11 +44,11 @@ spec_sql_exists_table <- list(
 
   #' An error is also raised
   exists_table_error = function(con, table_name = "test") {
-      dbWriteTable(con, "test", data.frame(a = 1L))
-      #' if `name` cannot be processed with [dbQuoteIdentifier()]
-      expect_error(dbExistsTable(con, NA))
-      #' or if this results in a non-scalar.
-      expect_error(dbExistsTable(con, c("test", "test")))
+    dbWriteTable(con, "test", data.frame(a = 1L))
+    #' if `name` cannot be processed with [dbQuoteIdentifier()]
+    expect_error(dbExistsTable(con, NA))
+    #' or if this results in a non-scalar.
+    expect_error(dbExistsTable(con, c("test", "test")))
   },
 
   #' @section Specification:
@@ -81,10 +81,10 @@ spec_sql_exists_table <- list(
   #'
   #' For all tables listed by [dbListTables()], `dbExistsTable()` returns `TRUE`.
   exists_table_list = function(con, table_name) {
-      dbWriteTable(con, table_name, data.frame(a = 1))
-      for (table_name in dbListTables(con)) {
-        eval(bquote(expect_true(dbExistsTable(con, .(table_name)))))
-      }
+    dbWriteTable(con, table_name, data.frame(a = 1))
+    for (table_name in dbListTables(con)) {
+      eval(bquote(expect_true(dbExistsTable(con, .(table_name)))))
+    }
   },
   #
   NULL

--- a/R/spec-sql-exists-table.R
+++ b/R/spec-sql-exists-table.R
@@ -43,7 +43,7 @@ spec_sql_exists_table <- list(
   },
 
   #' An error is also raised
-  exists_table_error = function(con) with_remove_test_table({
+  exists_table_error = function(con) with_remove_test_table(name = "test", {
       dbWriteTable(con, "test", data.frame(a = 1L))
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbExistsTable(con, NA))

--- a/R/spec-sql-exists-table.R
+++ b/R/spec-sql-exists-table.R
@@ -27,7 +27,9 @@ spec_sql_exists_table <- list(
         expect_true(expect_visible(dbExistsTable(con, "test")))
       }
     })
-
+  },
+  # second stage
+  exists_table = function(ctx, con) {
     expect_false(expect_visible(dbExistsTable(con, "iris")))
   },
 

--- a/R/spec-sql-exists-table.R
+++ b/R/spec-sql-exists-table.R
@@ -17,18 +17,21 @@ spec_sql_exists_table <- list(
     dbWriteTable(con, "iris", iris)
 
     expect_true(expect_visible(dbExistsTable(con, "iris")))
-
-    expect_false(expect_visible(dbExistsTable(con, "test")))
-
-    #' This includes temporary tables if supported by the database.
-    if (isTRUE(ctx$tweaks$temporary_tables)) {
-      dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
-      expect_true(expect_visible(dbExistsTable(con, "test")))
-    }
   },
   # second stage
   exists_table = function(ctx, con) {
     expect_false(expect_visible(dbExistsTable(con, "iris")))
+  },
+
+  #' 
+  #' This includes temporary tables if supported by the database.
+  exists_table_temporary = function(ctx, con, table_name = "test") {
+    expect_false(expect_visible(dbExistsTable(con, table_name)))
+
+    if (isTRUE(ctx$tweaks$temporary_tables)) {
+      dbWriteTable(con, table_name, data.frame(a = 1L), temporary = TRUE)
+      expect_true(expect_visible(dbExistsTable(con, table_name)))
+    }
   },
 
   #'
@@ -44,11 +47,11 @@ spec_sql_exists_table <- list(
 
   #' An error is also raised
   exists_table_error = function(con, table_name = "test") {
-    dbWriteTable(con, "test", data.frame(a = 1L))
+    dbWriteTable(con, table_name, data.frame(a = 1L))
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbExistsTable(con, NA))
     #' or if this results in a non-scalar.
-    expect_error(dbExistsTable(con, c("test", "test")))
+    expect_error(dbExistsTable(con, c(table_name, table_name)))
   },
 
   #' @section Specification:

--- a/R/spec-sql-exists-table.R
+++ b/R/spec-sql-exists-table.R
@@ -80,12 +80,12 @@ spec_sql_exists_table <- list(
 
   #'
   #' For all tables listed by [dbListTables()], `dbExistsTable()` returns `TRUE`.
-  exists_table_list = function(con) with_remove_test_table(name = table_name <- random_table_name(), {
+  exists_table_list = function(con, table_name) {
       dbWriteTable(con, table_name, data.frame(a = 1))
       for (table_name in dbListTables(con)) {
         eval(bquote(expect_true(dbExistsTable(con, .(table_name)))))
       }
-  }), # with_remove_test_table
+  },
   #
   NULL
 )

--- a/R/spec-sql-exists-table.R
+++ b/R/spec-sql-exists-table.R
@@ -11,8 +11,7 @@ spec_sql_exists_table <- list(
   #' @return
   #' `dbExistsTable()` returns a logical scalar, `TRUE` if the table or view
   #' specified by the `name` argument exists, `FALSE` otherwise.
-  exists_table = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  exists_table = function(ctx, con) with_remove_test_table(name = "iris", {
       expect_false(expect_visible(dbExistsTable(con, "iris")))
       iris <- get_iris(ctx)
       dbWriteTable(con, "iris", iris)
@@ -26,8 +25,7 @@ spec_sql_exists_table <- list(
         dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
         expect_true(expect_visible(dbExistsTable(con, "test")))
       }
-    })
-  },
+  }), # with_remove_test_table
   # second stage
   exists_table = function(ctx, con) {
     expect_false(expect_visible(dbExistsTable(con, "iris")))
@@ -45,15 +43,13 @@ spec_sql_exists_table <- list(
   },
 
   #' An error is also raised
-  exists_table_error = function(con) {
-    with_remove_test_table({
+  exists_table_error = function(con) with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1L))
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbExistsTable(con, NA))
       #' or if this results in a non-scalar.
       expect_error(dbExistsTable(con, c("test", "test")))
-    })
-  },
+  }), # with_remove_test_table
 
   #' @section Specification:
   #' The `name` argument is processed as follows,
@@ -84,14 +80,12 @@ spec_sql_exists_table <- list(
 
   #'
   #' For all tables listed by [dbListTables()], `dbExistsTable()` returns `TRUE`.
-  exists_table_list = function(con) {
-    with_remove_test_table(name = table_name <- random_table_name(), {
+  exists_table_list = function(con) with_remove_test_table(name = table_name <- random_table_name(), {
       dbWriteTable(con, table_name, data.frame(a = 1))
       for (table_name in dbListTables(con)) {
         eval(bquote(expect_true(dbExistsTable(con, .(table_name)))))
       }
-    })
-  },
+  }), # with_remove_test_table
   #
   NULL
 )

--- a/R/spec-sql-exists-table.R
+++ b/R/spec-sql-exists-table.R
@@ -11,7 +11,7 @@ spec_sql_exists_table <- list(
   #' @return
   #' `dbExistsTable()` returns a logical scalar, `TRUE` if the table or view
   #' specified by the `name` argument exists, `FALSE` otherwise.
-  exists_table = function(ctx, con) with_remove_test_table(name = "iris", {
+  exists_table = function(ctx, con, table_name = "iris") {
       expect_false(expect_visible(dbExistsTable(con, "iris")))
       iris <- get_iris(ctx)
       dbWriteTable(con, "iris", iris)
@@ -25,7 +25,7 @@ spec_sql_exists_table <- list(
         dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
         expect_true(expect_visible(dbExistsTable(con, "test")))
       }
-  }), # with_remove_test_table
+  },
   # second stage
   exists_table = function(ctx, con) {
     expect_false(expect_visible(dbExistsTable(con, "iris")))
@@ -43,13 +43,13 @@ spec_sql_exists_table <- list(
   },
 
   #' An error is also raised
-  exists_table_error = function(con) with_remove_test_table(name = "test", {
+  exists_table_error = function(con, table_name = "test") {
       dbWriteTable(con, "test", data.frame(a = 1L))
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbExistsTable(con, NA))
       #' or if this results in a non-scalar.
       expect_error(dbExistsTable(con, c("test", "test")))
-  }), # with_remove_test_table
+  },
 
   #' @section Specification:
   #' The `name` argument is processed as follows,

--- a/R/spec-sql-list-fields.R
+++ b/R/spec-sql-list-fields.R
@@ -10,8 +10,7 @@ spec_sql_list_fields <- list(
 
   #' @return
   #' `dbListFields()`
-  list_fields = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  list_fields = function(ctx, con) with_remove_test_table(name = "iris", {
       iris <- get_iris(ctx)
       dbWriteTable(con, "iris", iris)
 
@@ -21,11 +20,9 @@ spec_sql_list_fields <- list(
       #' that enumerates all fields
       #' in the table in the correct order.
       expect_identical(fields, names(iris))
-    })
-  },
+  }), # with_remove_test_table
   #' This also works for temporary tables if supported by the database.
-  list_fields_temporary = function(ctx, con) {
-    with_remove_test_table({
+  list_fields_temporary = function(ctx, con) with_remove_test_table({
       if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
         dbWriteTable(con, "test", data.frame(a = 1L, b = 2L), temporary = TRUE)
         fields <- dbListFields(con, "test")
@@ -34,8 +31,7 @@ spec_sql_list_fields <- list(
         #' The returned names are suitable for quoting with `dbQuoteIdentifier()`.
         expect_equal(dbQuoteIdentifier(con, fields), dbQuoteIdentifier(con, c("a", "b")))
       }
-    })
-  },
+  }), # with_remove_test_table
 
   #' If the table does not exist, an error is raised.
   list_fields_wrong_table = function(con) {
@@ -71,20 +67,17 @@ spec_sql_list_fields <- list(
   #'
   #' - a string
   #' - the return value of [dbQuoteIdentifier()]
-  list_fields_quoted = function(con) {
-    with_remove_test_table({
+  list_fields_quoted = function(con) with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1L, b = 2L))
       expect_identical(
         dbListFields(con, dbQuoteIdentifier(con, "test")),
         c("a", "b")
       )
-    })
-  },
+  }), # with_remove_test_table
 
   #' - a value from the `table` column from the return value of
   #'   [dbListObjects()] where `is_prefix` is `FALSE`
-  list_fields_object = function(con) {
-    with_remove_test_table({
+  list_fields_object = function(con) with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1L, b = 2L))
       objects <- dbListObjects(con)
       expect_gt(nrow(objects), 0)
@@ -93,17 +86,14 @@ spec_sql_list_fields <- list(
         dbListFields(con, objects$table[[1]]),
         dbListFields(con, dbQuoteIdentifier(con, objects$table[[1]]))
       )
-    })
-  },
+  }), # with_remove_test_table
 
   #'
   #' A column named `row_names` is treated like any other column.
-  list_fields_row_names = function(con) {
-    with_remove_test_table({
+  list_fields_row_names = function(con) with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1L, row_names = 2L))
       expect_identical(dbListFields(con, "test"), c("a", "row_names"))
-    })
-  },
+  }), # with_remove_test_table
   #
   NULL
 )

--- a/R/spec-sql-list-fields.R
+++ b/R/spec-sql-list-fields.R
@@ -11,26 +11,26 @@ spec_sql_list_fields <- list(
   #' @return
   #' `dbListFields()`
   list_fields = function(ctx, con, table_name = "iris") {
-      iris <- get_iris(ctx)
-      dbWriteTable(con, "iris", iris)
+    iris <- get_iris(ctx)
+    dbWriteTable(con, "iris", iris)
 
-      fields <- dbListFields(con, "iris")
-      #' returns a character vector
-      expect_is(fields, "character")
-      #' that enumerates all fields
-      #' in the table in the correct order.
-      expect_identical(fields, names(iris))
+    fields <- dbListFields(con, "iris")
+    #' returns a character vector
+    expect_is(fields, "character")
+    #' that enumerates all fields
+    #' in the table in the correct order.
+    expect_identical(fields, names(iris))
   },
   #' This also works for temporary tables if supported by the database.
   list_fields_temporary = function(ctx, con, table_name = "test") {
-      if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
-        dbWriteTable(con, "test", data.frame(a = 1L, b = 2L), temporary = TRUE)
-        fields <- dbListFields(con, "test")
-        expect_equal(fields, c("a", "b"))
+    if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
+      dbWriteTable(con, "test", data.frame(a = 1L, b = 2L), temporary = TRUE)
+      fields <- dbListFields(con, "test")
+      expect_equal(fields, c("a", "b"))
 
-        #' The returned names are suitable for quoting with `dbQuoteIdentifier()`.
-        expect_equal(dbQuoteIdentifier(con, fields), dbQuoteIdentifier(con, c("a", "b")))
-      }
+      #' The returned names are suitable for quoting with `dbQuoteIdentifier()`.
+      expect_equal(dbQuoteIdentifier(con, fields), dbQuoteIdentifier(con, c("a", "b")))
+    }
   },
 
   #' If the table does not exist, an error is raised.
@@ -68,31 +68,31 @@ spec_sql_list_fields <- list(
   #' - a string
   #' - the return value of [dbQuoteIdentifier()]
   list_fields_quoted = function(con, table_name = "test") {
-      dbWriteTable(con, "test", data.frame(a = 1L, b = 2L))
-      expect_identical(
-        dbListFields(con, dbQuoteIdentifier(con, "test")),
-        c("a", "b")
-      )
+    dbWriteTable(con, "test", data.frame(a = 1L, b = 2L))
+    expect_identical(
+      dbListFields(con, dbQuoteIdentifier(con, "test")),
+      c("a", "b")
+    )
   },
 
   #' - a value from the `table` column from the return value of
   #'   [dbListObjects()] where `is_prefix` is `FALSE`
   list_fields_object = function(con, table_name = "test") {
-      dbWriteTable(con, "test", data.frame(a = 1L, b = 2L))
-      objects <- dbListObjects(con)
-      expect_gt(nrow(objects), 0)
-      expect_false(all(objects$is_prefix))
-      expect_identical(
-        dbListFields(con, objects$table[[1]]),
-        dbListFields(con, dbQuoteIdentifier(con, objects$table[[1]]))
-      )
+    dbWriteTable(con, "test", data.frame(a = 1L, b = 2L))
+    objects <- dbListObjects(con)
+    expect_gt(nrow(objects), 0)
+    expect_false(all(objects$is_prefix))
+    expect_identical(
+      dbListFields(con, objects$table[[1]]),
+      dbListFields(con, dbQuoteIdentifier(con, objects$table[[1]]))
+    )
   },
 
   #'
   #' A column named `row_names` is treated like any other column.
   list_fields_row_names = function(con, table_name = "test") {
-      dbWriteTable(con, "test", data.frame(a = 1L, row_names = 2L))
-      expect_identical(dbListFields(con, "test"), c("a", "row_names"))
+    dbWriteTable(con, "test", data.frame(a = 1L, row_names = 2L))
+    expect_identical(dbListFields(con, "test"), c("a", "row_names"))
   },
   #
   NULL

--- a/R/spec-sql-list-fields.R
+++ b/R/spec-sql-list-fields.R
@@ -22,7 +22,7 @@ spec_sql_list_fields <- list(
       expect_identical(fields, names(iris))
   }), # with_remove_test_table
   #' This also works for temporary tables if supported by the database.
-  list_fields_temporary = function(ctx, con) with_remove_test_table({
+  list_fields_temporary = function(ctx, con) with_remove_test_table(name = "test", {
       if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
         dbWriteTable(con, "test", data.frame(a = 1L, b = 2L), temporary = TRUE)
         fields <- dbListFields(con, "test")
@@ -67,7 +67,7 @@ spec_sql_list_fields <- list(
   #'
   #' - a string
   #' - the return value of [dbQuoteIdentifier()]
-  list_fields_quoted = function(con) with_remove_test_table({
+  list_fields_quoted = function(con) with_remove_test_table(name = "test", {
       dbWriteTable(con, "test", data.frame(a = 1L, b = 2L))
       expect_identical(
         dbListFields(con, dbQuoteIdentifier(con, "test")),
@@ -77,7 +77,7 @@ spec_sql_list_fields <- list(
 
   #' - a value from the `table` column from the return value of
   #'   [dbListObjects()] where `is_prefix` is `FALSE`
-  list_fields_object = function(con) with_remove_test_table({
+  list_fields_object = function(con) with_remove_test_table(name = "test", {
       dbWriteTable(con, "test", data.frame(a = 1L, b = 2L))
       objects <- dbListObjects(con)
       expect_gt(nrow(objects), 0)
@@ -90,7 +90,7 @@ spec_sql_list_fields <- list(
 
   #'
   #' A column named `row_names` is treated like any other column.
-  list_fields_row_names = function(con) with_remove_test_table({
+  list_fields_row_names = function(con) with_remove_test_table(name = "test", {
       dbWriteTable(con, "test", data.frame(a = 1L, row_names = 2L))
       expect_identical(dbListFields(con, "test"), c("a", "row_names"))
   }), # with_remove_test_table

--- a/R/spec-sql-list-fields.R
+++ b/R/spec-sql-list-fields.R
@@ -22,9 +22,10 @@ spec_sql_list_fields <- list(
       #' in the table in the correct order.
       expect_identical(fields, names(iris))
     })
-
+  },
+  #' This also works for temporary tables if supported by the database.
+  list_fields_temporary = function(ctx, con) {
     with_remove_test_table({
-      #' This also works for temporary tables if supported by the database.
       if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
         dbWriteTable(con, "test", data.frame(a = 1L, b = 2L), temporary = TRUE)
         fields <- dbListFields(con, "test")

--- a/R/spec-sql-list-fields.R
+++ b/R/spec-sql-list-fields.R
@@ -24,8 +24,8 @@ spec_sql_list_fields <- list(
   #' This also works for temporary tables if supported by the database.
   list_fields_temporary = function(ctx, con, table_name = "test") {
     if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
-      dbWriteTable(con, "test", data.frame(a = 1L, b = 2L), temporary = TRUE)
-      fields <- dbListFields(con, "test")
+      dbWriteTable(con, table_name, data.frame(a = 1L, b = 2L), temporary = TRUE)
+      fields <- dbListFields(con, table_name)
       expect_equal(fields, c("a", "b"))
 
       #' The returned names are suitable for quoting with `dbQuoteIdentifier()`.
@@ -68,9 +68,9 @@ spec_sql_list_fields <- list(
   #' - a string
   #' - the return value of [dbQuoteIdentifier()]
   list_fields_quoted = function(con, table_name = "test") {
-    dbWriteTable(con, "test", data.frame(a = 1L, b = 2L))
+    dbWriteTable(con, table_name, data.frame(a = 1L, b = 2L))
     expect_identical(
-      dbListFields(con, dbQuoteIdentifier(con, "test")),
+      dbListFields(con, dbQuoteIdentifier(con, table_name)),
       c("a", "b")
     )
   },
@@ -78,7 +78,7 @@ spec_sql_list_fields <- list(
   #' - a value from the `table` column from the return value of
   #'   [dbListObjects()] where `is_prefix` is `FALSE`
   list_fields_object = function(con, table_name = "test") {
-    dbWriteTable(con, "test", data.frame(a = 1L, b = 2L))
+    dbWriteTable(con, table_name, data.frame(a = 1L, b = 2L))
     objects <- dbListObjects(con)
     expect_gt(nrow(objects), 0)
     expect_false(all(objects$is_prefix))
@@ -91,8 +91,8 @@ spec_sql_list_fields <- list(
   #'
   #' A column named `row_names` is treated like any other column.
   list_fields_row_names = function(con, table_name = "test") {
-    dbWriteTable(con, "test", data.frame(a = 1L, row_names = 2L))
-    expect_identical(dbListFields(con, "test"), c("a", "row_names"))
+    dbWriteTable(con, table_name, data.frame(a = 1L, row_names = 2L))
+    expect_identical(dbListFields(con, table_name), c("a", "row_names"))
   },
   #
   NULL

--- a/R/spec-sql-list-fields.R
+++ b/R/spec-sql-list-fields.R
@@ -10,7 +10,7 @@ spec_sql_list_fields <- list(
 
   #' @return
   #' `dbListFields()`
-  list_fields = function(ctx, con) with_remove_test_table(name = "iris", {
+  list_fields = function(ctx, con, table_name = "iris") {
       iris <- get_iris(ctx)
       dbWriteTable(con, "iris", iris)
 
@@ -20,9 +20,9 @@ spec_sql_list_fields <- list(
       #' that enumerates all fields
       #' in the table in the correct order.
       expect_identical(fields, names(iris))
-  }), # with_remove_test_table
+  },
   #' This also works for temporary tables if supported by the database.
-  list_fields_temporary = function(ctx, con) with_remove_test_table(name = "test", {
+  list_fields_temporary = function(ctx, con, table_name = "test") {
       if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
         dbWriteTable(con, "test", data.frame(a = 1L, b = 2L), temporary = TRUE)
         fields <- dbListFields(con, "test")
@@ -31,7 +31,7 @@ spec_sql_list_fields <- list(
         #' The returned names are suitable for quoting with `dbQuoteIdentifier()`.
         expect_equal(dbQuoteIdentifier(con, fields), dbQuoteIdentifier(con, c("a", "b")))
       }
-  }), # with_remove_test_table
+  },
 
   #' If the table does not exist, an error is raised.
   list_fields_wrong_table = function(con) {
@@ -67,17 +67,17 @@ spec_sql_list_fields <- list(
   #'
   #' - a string
   #' - the return value of [dbQuoteIdentifier()]
-  list_fields_quoted = function(con) with_remove_test_table(name = "test", {
+  list_fields_quoted = function(con, table_name = "test") {
       dbWriteTable(con, "test", data.frame(a = 1L, b = 2L))
       expect_identical(
         dbListFields(con, dbQuoteIdentifier(con, "test")),
         c("a", "b")
       )
-  }), # with_remove_test_table
+  },
 
   #' - a value from the `table` column from the return value of
   #'   [dbListObjects()] where `is_prefix` is `FALSE`
-  list_fields_object = function(con) with_remove_test_table(name = "test", {
+  list_fields_object = function(con, table_name = "test") {
       dbWriteTable(con, "test", data.frame(a = 1L, b = 2L))
       objects <- dbListObjects(con)
       expect_gt(nrow(objects), 0)
@@ -86,14 +86,14 @@ spec_sql_list_fields <- list(
         dbListFields(con, objects$table[[1]]),
         dbListFields(con, dbQuoteIdentifier(con, objects$table[[1]]))
       )
-  }), # with_remove_test_table
+  },
 
   #'
   #' A column named `row_names` is treated like any other column.
-  list_fields_row_names = function(con) with_remove_test_table(name = "test", {
+  list_fields_row_names = function(con, table_name = "test") {
       dbWriteTable(con, "test", data.frame(a = 1L, row_names = 2L))
       expect_identical(dbListFields(con, "test"), c("a", "row_names"))
-  }), # with_remove_test_table
+  },
   #
   NULL
 )

--- a/R/spec-sql-list-objects.R
+++ b/R/spec-sql-list-objects.R
@@ -41,14 +41,25 @@ spec_sql_list_objects <- list(
       iris <- get_iris(ctx)
       dbWriteTable(con, "iris", iris)
 
-      #' are part of the data frame,
+      #' are part of the data frame.
       objects <- dbListObjects(con)
       quoted_tables <- vapply(objects$table, dbQuoteIdentifier, conn = con, character(1))
       expect_true(dbQuoteIdentifier(con, "iris") %in% quoted_tables)
     })
+  },
+  # second stage
+  list_objects = function(ctx, con) {
+    #' As soon a table is removed from the database,
+    #' it is also removed from the data frame of database objects.
+    objects <- dbListObjects(con)
+    quoted_tables <- vapply(objects$table, dbQuoteIdentifier, conn = con, character(1))
+    expect_false(dbQuoteIdentifier(con, "iris") %in% quoted_tables)
+  },
 
+  #'
+  #' The same applies to temporary objects if supported by the database.
+  list_objects_temporary = function(ctx, con) {
     with_remove_test_table({
-      #' including temporary objects if supported by the database.
       if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
         dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
 
@@ -57,15 +68,11 @@ spec_sql_list_objects <- list(
         expect_true(dbQuoteIdentifier(con, "test") %in% quoted_tables)
       }
     })
+  },
 
-    #' As soon a table is removed from the database,
-    #' it is also removed from the data frame of database objects.
-    objects <- dbListObjects(con)
-    quoted_tables <- vapply(objects$table, dbQuoteIdentifier, conn = con, character(1))
-    expect_false(dbQuoteIdentifier(con, "iris") %in% quoted_tables)
-
-    #'
-    #' The returned names are suitable for quoting with `dbQuoteIdentifier()`.
+  #'
+  #' The returned names are suitable for quoting with `dbQuoteIdentifier()`.
+  list_objects_quote = function(ctx, con) {
     if (isTRUE(ctx$tweaks$strict_identifier)) {
       table_names <- "a"
     } else {

--- a/R/spec-sql-list-objects.R
+++ b/R/spec-sql-list-objects.R
@@ -56,7 +56,7 @@ spec_sql_list_objects <- list(
 
   #'
   #' The same applies to temporary objects if supported by the database.
-  list_objects_temporary = function(ctx, con) with_remove_test_table({
+  list_objects_temporary = function(ctx, con) with_remove_test_table(name = "test", {
       if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
         dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
 

--- a/R/spec-sql-list-objects.R
+++ b/R/spec-sql-list-objects.R
@@ -10,7 +10,7 @@ spec_sql_list_objects <- list(
 
   #' @return
   #' `dbListObjects()`
-  list_objects = function(ctx, con) with_remove_test_table(name = "iris", {
+  list_objects = function(ctx, con, table_name = "iris") {
       objects <- dbListObjects(con)
       #' returns a data frame
       expect_is(objects, "data.frame")
@@ -44,7 +44,7 @@ spec_sql_list_objects <- list(
       objects <- dbListObjects(con)
       quoted_tables <- vapply(objects$table, dbQuoteIdentifier, conn = con, character(1))
       expect_true(dbQuoteIdentifier(con, "iris") %in% quoted_tables)
-  }), # with_remove_test_table
+  },
   # second stage
   list_objects = function(ctx, con) {
     #' As soon a table is removed from the database,
@@ -56,7 +56,7 @@ spec_sql_list_objects <- list(
 
   #'
   #' The same applies to temporary objects if supported by the database.
-  list_objects_temporary = function(ctx, con) with_remove_test_table(name = "test", {
+  list_objects_temporary = function(ctx, con, table_name = "test") {
       if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
         dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
 
@@ -64,7 +64,7 @@ spec_sql_list_objects <- list(
         quoted_tables <- vapply(objects$table, dbQuoteIdentifier, conn = con, character(1))
         expect_true(dbQuoteIdentifier(con, "test") %in% quoted_tables)
       }
-  }), # with_remove_test_table
+  },
 
   #'
   #' The returned names are suitable for quoting with `dbQuoteIdentifier()`.

--- a/R/spec-sql-list-objects.R
+++ b/R/spec-sql-list-objects.R
@@ -10,8 +10,7 @@ spec_sql_list_objects <- list(
 
   #' @return
   #' `dbListObjects()`
-  list_objects = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  list_objects = function(ctx, con) with_remove_test_table(name = "iris", {
       objects <- dbListObjects(con)
       #' returns a data frame
       expect_is(objects, "data.frame")
@@ -45,8 +44,7 @@ spec_sql_list_objects <- list(
       objects <- dbListObjects(con)
       quoted_tables <- vapply(objects$table, dbQuoteIdentifier, conn = con, character(1))
       expect_true(dbQuoteIdentifier(con, "iris") %in% quoted_tables)
-    })
-  },
+  }), # with_remove_test_table
   # second stage
   list_objects = function(ctx, con) {
     #' As soon a table is removed from the database,
@@ -58,8 +56,7 @@ spec_sql_list_objects <- list(
 
   #'
   #' The same applies to temporary objects if supported by the database.
-  list_objects_temporary = function(ctx, con) {
-    with_remove_test_table({
+  list_objects_temporary = function(ctx, con) with_remove_test_table({
       if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
         dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
 
@@ -67,8 +64,7 @@ spec_sql_list_objects <- list(
         quoted_tables <- vapply(objects$table, dbQuoteIdentifier, conn = con, character(1))
         expect_true(dbQuoteIdentifier(con, "test") %in% quoted_tables)
       }
-    })
-  },
+  }), # with_remove_test_table
 
   #'
   #' The returned names are suitable for quoting with `dbQuoteIdentifier()`.

--- a/R/spec-sql-list-objects.R
+++ b/R/spec-sql-list-objects.R
@@ -11,39 +11,39 @@ spec_sql_list_objects <- list(
   #' @return
   #' `dbListObjects()`
   list_objects = function(ctx, con, table_name = "iris") {
-      objects <- dbListObjects(con)
-      #' returns a data frame
-      expect_is(objects, "data.frame")
-      #' with columns
-      cols <- c("table", "is_prefix")
-      #' `table` and `is_prefix` (in that order),
-      expect_equal(names(objects)[seq_along(cols)], cols)
-      #' optionally with other columns with a dot (`.`) prefix.
-      expect_true(all(grepl("^[.]", names(objects)[-seq_along(cols)])))
+    objects <- dbListObjects(con)
+    #' returns a data frame
+    expect_is(objects, "data.frame")
+    #' with columns
+    cols <- c("table", "is_prefix")
+    #' `table` and `is_prefix` (in that order),
+    expect_equal(names(objects)[seq_along(cols)], cols)
+    #' optionally with other columns with a dot (`.`) prefix.
+    expect_true(all(grepl("^[.]", names(objects)[-seq_along(cols)])))
 
-      #' The `table` column is of type list.
-      expect_equal(typeof(objects$table), "list")
-      #' Each object in this list is suitable for use as argument in [dbQuoteIdentifier()].
-      expect_error(lapply(objects$table, dbQuoteIdentifier, conn = con), NA)
+    #' The `table` column is of type list.
+    expect_equal(typeof(objects$table), "list")
+    #' Each object in this list is suitable for use as argument in [dbQuoteIdentifier()].
+    expect_error(lapply(objects$table, dbQuoteIdentifier, conn = con), NA)
 
-      #' The `is_prefix` column is a logical.
-      expect_is(objects$is_prefix, "logical")
+    #' The `is_prefix` column is a logical.
+    expect_is(objects$is_prefix, "logical")
 
-      #' This data frame contains one row for each object (schema, table
-      expect_false("iris" %in% objects)
-      #' and view)
-      # TODO
-      #' accessible from the prefix (if passed) or from the global namespace
-      #' (if prefix is omitted).
+    #' This data frame contains one row for each object (schema, table
+    expect_false("iris" %in% objects)
+    #' and view)
+    # TODO
+    #' accessible from the prefix (if passed) or from the global namespace
+    #' (if prefix is omitted).
 
-      #' Tables added with [dbWriteTable()]
-      iris <- get_iris(ctx)
-      dbWriteTable(con, "iris", iris)
+    #' Tables added with [dbWriteTable()]
+    iris <- get_iris(ctx)
+    dbWriteTable(con, "iris", iris)
 
-      #' are part of the data frame.
-      objects <- dbListObjects(con)
-      quoted_tables <- vapply(objects$table, dbQuoteIdentifier, conn = con, character(1))
-      expect_true(dbQuoteIdentifier(con, "iris") %in% quoted_tables)
+    #' are part of the data frame.
+    objects <- dbListObjects(con)
+    quoted_tables <- vapply(objects$table, dbQuoteIdentifier, conn = con, character(1))
+    expect_true(dbQuoteIdentifier(con, "iris") %in% quoted_tables)
   },
   # second stage
   list_objects = function(ctx, con) {
@@ -57,13 +57,13 @@ spec_sql_list_objects <- list(
   #'
   #' The same applies to temporary objects if supported by the database.
   list_objects_temporary = function(ctx, con, table_name = "test") {
-      if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
-        dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
+    if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
+      dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
 
-        objects <- dbListObjects(con)
-        quoted_tables <- vapply(objects$table, dbQuoteIdentifier, conn = con, character(1))
-        expect_true(dbQuoteIdentifier(con, "test") %in% quoted_tables)
-      }
+      objects <- dbListObjects(con)
+      quoted_tables <- vapply(objects$table, dbQuoteIdentifier, conn = con, character(1))
+      expect_true(dbQuoteIdentifier(con, "test") %in% quoted_tables)
+    }
   },
 
   #'

--- a/R/spec-sql-list-objects.R
+++ b/R/spec-sql-list-objects.R
@@ -58,11 +58,11 @@ spec_sql_list_objects <- list(
   #' The same applies to temporary objects if supported by the database.
   list_objects_temporary = function(ctx, con, table_name = "test") {
     if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
-      dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
+      dbWriteTable(con, table_name, data.frame(a = 1L), temporary = TRUE)
 
       objects <- dbListObjects(con)
       quoted_tables <- vapply(objects$table, dbQuoteIdentifier, conn = con, character(1))
-      expect_true(dbQuoteIdentifier(con, "test") %in% quoted_tables)
+      expect_true(dbQuoteIdentifier(con, table_name) %in% quoted_tables)
     }
   },
 

--- a/R/spec-sql-list-tables.R
+++ b/R/spec-sql-list-tables.R
@@ -38,15 +38,13 @@ spec_sql_list_tables <- list(
   },
   #'
   #' The same applies to temporary tables if supported by the database.
-  list_tables_temporary = function(ctx, con) {
-    with_remove_test_table({
+  list_tables_temporary = function(ctx, con) with_remove_test_table({
       if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
         dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
         tables <- dbListTables(con)
         expect_true("test" %in% tables)
       }
-    })
-  },
+  }), # with_remove_test_table
 
   #'
   #' The returned names are suitable for quoting with `dbQuoteIdentifier()`.

--- a/R/spec-sql-list-tables.R
+++ b/R/spec-sql-list-tables.R
@@ -40,9 +40,9 @@ spec_sql_list_tables <- list(
   #' The same applies to temporary tables if supported by the database.
   list_tables_temporary = function(ctx, con, table_name = "test") {
     if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
-      dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
+      dbWriteTable(con, table_name, data.frame(a = 1L), temporary = TRUE)
       tables <- dbListTables(con)
-      expect_true("test" %in% tables)
+      expect_true(table_name %in% tables)
     }
   },
 

--- a/R/spec-sql-list-tables.R
+++ b/R/spec-sql-list-tables.R
@@ -25,28 +25,32 @@ spec_sql_list_tables <- list(
       iris <- get_iris(ctx)
       dbWriteTable(con, "iris", iris)
 
-      #' are part of the list,
+      #' are part of the list.
       tables <- dbListTables(con)
       expect_true("iris" %in% tables)
   }), # with_remove_test_table
-  #
+  # second stage
+  list_tables = function(ctx, con) {
+    #' As soon a table is removed from the database,
+    #' it is also removed from the list of database tables.
+    tables <- dbListTables(con)
+    expect_false("iris" %in% tables)
+  },
+  #'
+  #' The same applies to temporary tables if supported by the database.
   list_tables_temporary = function(ctx, con) {
     with_remove_test_table({
-      #' including temporary tables if supported by the database.
       if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
         dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
         tables <- dbListTables(con)
         expect_true("test" %in% tables)
       }
     })
+  },
 
-    #' As soon a table is removed from the database,
-    #' it is also removed from the list of database tables.
-    tables <- dbListTables(con)
-    expect_false("iris" %in% tables)
-
-    #'
-    #' The returned names are suitable for quoting with `dbQuoteIdentifier()`.
+  #'
+  #' The returned names are suitable for quoting with `dbQuoteIdentifier()`.
+  list_tables_quote = function(ctx, con) {
     if (isTRUE(ctx$tweaks$strict_identifier)) {
       table_names <- "a"
     } else {

--- a/R/spec-sql-list-tables.R
+++ b/R/spec-sql-list-tables.R
@@ -38,7 +38,7 @@ spec_sql_list_tables <- list(
   },
   #'
   #' The same applies to temporary tables if supported by the database.
-  list_tables_temporary = function(ctx, con) with_remove_test_table({
+  list_tables_temporary = function(ctx, con) with_remove_test_table(name = "test", {
       if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
         dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
         tables <- dbListTables(con)

--- a/R/spec-sql-list-tables.R
+++ b/R/spec-sql-list-tables.R
@@ -10,7 +10,7 @@ spec_sql_list_tables <- list(
 
   #' @return
   #' `dbListTables()`
-  list_tables = function(ctx, con) with_remove_test_table(name = "iris", {
+  list_tables = function(ctx, con, table_name = "iris") {
       tables <- dbListTables(con)
       #' returns a character vector
       expect_is(tables, "character")
@@ -28,7 +28,7 @@ spec_sql_list_tables <- list(
       #' are part of the list.
       tables <- dbListTables(con)
       expect_true("iris" %in% tables)
-  }), # with_remove_test_table
+  },
   # second stage
   list_tables = function(ctx, con) {
     #' As soon a table is removed from the database,
@@ -38,13 +38,13 @@ spec_sql_list_tables <- list(
   },
   #'
   #' The same applies to temporary tables if supported by the database.
-  list_tables_temporary = function(ctx, con) with_remove_test_table(name = "test", {
+  list_tables_temporary = function(ctx, con, table_name = "test") {
       if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
         dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
         tables <- dbListTables(con)
         expect_true("test" %in% tables)
       }
-  }), # with_remove_test_table
+  },
 
   #'
   #' The returned names are suitable for quoting with `dbQuoteIdentifier()`.

--- a/R/spec-sql-list-tables.R
+++ b/R/spec-sql-list-tables.R
@@ -10,8 +10,7 @@ spec_sql_list_tables <- list(
 
   #' @return
   #' `dbListTables()`
-  list_tables = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  list_tables = function(ctx, con) with_remove_test_table(name = "iris", {
       tables <- dbListTables(con)
       #' returns a character vector
       expect_is(tables, "character")
@@ -29,8 +28,7 @@ spec_sql_list_tables <- list(
       #' are part of the list,
       tables <- dbListTables(con)
       expect_true("iris" %in% tables)
-    })
-  },
+  }), # with_remove_test_table
   #
   list_tables_temporary = function(ctx, con) {
     with_remove_test_table({

--- a/R/spec-sql-list-tables.R
+++ b/R/spec-sql-list-tables.R
@@ -11,23 +11,23 @@ spec_sql_list_tables <- list(
   #' @return
   #' `dbListTables()`
   list_tables = function(ctx, con, table_name = "iris") {
-      tables <- dbListTables(con)
-      #' returns a character vector
-      expect_is(tables, "character")
-      #' that enumerates all tables
-      expect_false("iris" %in% tables)
+    tables <- dbListTables(con)
+    #' returns a character vector
+    expect_is(tables, "character")
+    #' that enumerates all tables
+    expect_false("iris" %in% tables)
 
-      #' and views
-      # TODO
-      #' in the database.
+    #' and views
+    # TODO
+    #' in the database.
 
-      #' Tables added with [dbWriteTable()]
-      iris <- get_iris(ctx)
-      dbWriteTable(con, "iris", iris)
+    #' Tables added with [dbWriteTable()]
+    iris <- get_iris(ctx)
+    dbWriteTable(con, "iris", iris)
 
-      #' are part of the list.
-      tables <- dbListTables(con)
-      expect_true("iris" %in% tables)
+    #' are part of the list.
+    tables <- dbListTables(con)
+    expect_true("iris" %in% tables)
   },
   # second stage
   list_tables = function(ctx, con) {
@@ -39,11 +39,11 @@ spec_sql_list_tables <- list(
   #'
   #' The same applies to temporary tables if supported by the database.
   list_tables_temporary = function(ctx, con, table_name = "test") {
-      if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
-        dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
-        tables <- dbListTables(con)
-        expect_true("test" %in% tables)
-      }
+    if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
+      dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
+      tables <- dbListTables(con)
+      expect_true("test" %in% tables)
+    }
   },
 
   #'

--- a/R/spec-sql-read-table.R
+++ b/R/spec-sql-read-table.R
@@ -139,14 +139,14 @@ spec_sql_read_table <- list(
   }), # with_remove_test_table
   #
   read_table_check_names = function(ctx, con) {
-    #' If the database supports identifiers with special characters,
-    if (isTRUE(ctx$tweaks$strict_identifier)) {
-      skip("tweak: strict_identifier")
-    }
-
-    #' the columns in the returned data frame are converted to valid R
-    #' identifiers
     with_remove_test_table({
+      #' If the database supports identifiers with special characters,
+      if (isTRUE(ctx$tweaks$strict_identifier)) {
+        skip("tweak: strict_identifier")
+      }
+
+      #' the columns in the returned data frame are converted to valid R
+      #' identifiers
       test_in <- data.frame(a = 1:3, b = 4:6)
       names(test_in) <- c("with spaces", "with,comma")
       dbWriteTable(con, "test", test_in)
@@ -156,9 +156,15 @@ spec_sql_read_table <- list(
       expect_identical(names(test_out), make.names(names(test_out), unique = TRUE))
       expect_equal_df(test_out, setNames(test_in, names(test_out)))
     })
-
-    #' otherwise non-syntactic column names can be returned unquoted.
+  },
+  #
+  read_table_check_names_false = function(ctx, con) {
     with_remove_test_table({
+      if (isTRUE(ctx$tweaks$strict_identifier)) {
+        skip("tweak: strict_identifier")
+      }
+
+      #' If `check.names = FALSE`, the returned table has non-syntactic column names without quotes.
       test_in <- data.frame(a = 1:3, b = 4:6)
       names(test_in) <- c("with spaces", "with,comma")
       dbWriteTable(con, "test", test_in)

--- a/R/spec-sql-read-table.R
+++ b/R/spec-sql-read-table.R
@@ -13,26 +13,26 @@ spec_sql_read_table <- list(
   #' from the remote table, effectively the result of calling [dbGetQuery()]
   #' with `SELECT * FROM <name>`.
   read_table = function(ctx, con, table_name = "iris") {
-      iris_in <- get_iris(ctx)
-      dbWriteTable(con, "iris", iris_in)
-      iris_out <- check_df(dbReadTable(con, "iris"))
+    iris_in <- get_iris(ctx)
+    dbWriteTable(con, "iris", iris_in)
+    iris_out <- check_df(dbReadTable(con, "iris"))
 
-      expect_equal_df(iris_out, iris_in)
+    expect_equal_df(iris_out, iris_in)
   },
 
   #' An error is raised if the table does not exist.
   read_table_missing = function(con, table_name = "test") {
-      expect_error(dbReadTable(con, "test"))
+    expect_error(dbReadTable(con, "test"))
   },
 
   #' An empty table is returned as a data frame with zero rows.
   read_table_empty = function(ctx, con, table_name = "iris") {
-      iris_in <- get_iris(ctx)[integer(), ]
-      dbWriteTable(con, "iris", iris_in)
-      iris_out <- check_df(dbReadTable(con, "iris"))
+    iris_in <- get_iris(ctx)[integer(), ]
+    dbWriteTable(con, "iris", iris_in)
+    iris_out <- check_df(dbReadTable(con, "iris"))
 
-      expect_equal(nrow(iris_out), 0L)
-      expect_equal_df(iris_out, iris_in)
+    expect_equal(nrow(iris_out), 0L)
+    expect_equal_df(iris_out, iris_in)
   },
 
   #'
@@ -55,153 +55,153 @@ spec_sql_read_table <- list(
   },
   #
   read_table_row_names_true_exists = function(con, table_name = "mtcars") {
-      #' - If `TRUE`, a column named "row_names" is converted to row names,
-      row.names <- TRUE
+    #' - If `TRUE`, a column named "row_names" is converted to row names,
+    row.names <- TRUE
 
-      mtcars_in <- datasets::mtcars
-      dbWriteTable(con, "mtcars", mtcars_in, row.names = NA)
-      mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = row.names))
+    mtcars_in <- datasets::mtcars
+    dbWriteTable(con, "mtcars", mtcars_in, row.names = NA)
+    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = row.names))
 
-      expect_equal_df(mtcars_out, mtcars_in)
+    expect_equal_df(mtcars_out, mtcars_in)
   },
   #
   read_table_row_names_true_missing = function(ctx, con, table_name = "iris") {
-      #'   an error is raised if no such column exists.
-      row.names <- TRUE
+    #'   an error is raised if no such column exists.
+    row.names <- TRUE
 
-      iris_in <- get_iris(ctx)
-      dbWriteTable(con, "iris", iris_in, row.names = NA)
-      expect_error(dbReadTable(con, "iris", row.names = row.names))
+    iris_in <- get_iris(ctx)
+    dbWriteTable(con, "iris", iris_in, row.names = NA)
+    expect_error(dbReadTable(con, "iris", row.names = row.names))
   },
   #
   read_table_row_names_na_exists = function(con, table_name = "mtcars") {
-      #' - If `NA`, a column named "row_names" is converted to row names if it exists,
-      row.names <- NA
+    #' - If `NA`, a column named "row_names" is converted to row names if it exists,
+    row.names <- NA
 
-      mtcars_in <- datasets::mtcars
-      dbWriteTable(con, "mtcars", mtcars_in, row.names = TRUE)
-      mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = row.names))
+    mtcars_in <- datasets::mtcars
+    dbWriteTable(con, "mtcars", mtcars_in, row.names = TRUE)
+    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = row.names))
 
-      expect_equal_df(mtcars_out, mtcars_in)
+    expect_equal_df(mtcars_out, mtcars_in)
   },
   #
   read_table_row_names_na_missing = function(ctx, con, table_name = "iris") {
-      #'   otherwise no translation occurs.
-      row.names <- NA
+    #'   otherwise no translation occurs.
+    row.names <- NA
 
-      iris_in <- get_iris(ctx)
-      dbWriteTable(con, "iris", iris_in, row.names = FALSE)
-      iris_out <- check_df(dbReadTable(con, "iris", row.names = row.names))
+    iris_in <- get_iris(ctx)
+    dbWriteTable(con, "iris", iris_in, row.names = FALSE)
+    iris_out <- check_df(dbReadTable(con, "iris", row.names = row.names))
 
-      expect_equal_df(iris_out, iris_in)
+    expect_equal_df(iris_out, iris_in)
   },
   #
   read_table_row_names_string_exists = function(con, table_name = "mtcars") {
-      #' - If a string, this specifies the name of the column in the remote table
-      #'   that contains the row names,
-      row.names <- "make_model"
+    #' - If a string, this specifies the name of the column in the remote table
+    #'   that contains the row names,
+    row.names <- "make_model"
 
-      mtcars_in <- datasets::mtcars
-      mtcars_in$make_model <- rownames(mtcars_in)
-      mtcars_in <- unrowname(mtcars_in)
+    mtcars_in <- datasets::mtcars
+    mtcars_in$make_model <- rownames(mtcars_in)
+    mtcars_in <- unrowname(mtcars_in)
 
-      dbWriteTable(con, "mtcars", mtcars_in, row.names = FALSE)
-      mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = row.names))
+    dbWriteTable(con, "mtcars", mtcars_in, row.names = FALSE)
+    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = row.names))
 
-      expect_false("make_model" %in% names(mtcars_out))
-      expect_true(all(mtcars_in$make_model %in% rownames(mtcars_out)))
-      expect_true(all(rownames(mtcars_out) %in% mtcars_in$make_model))
-      expect_equal_df(unrowname(mtcars_out), mtcars_in[names(mtcars_in) != "make_model"])
+    expect_false("make_model" %in% names(mtcars_out))
+    expect_true(all(mtcars_in$make_model %in% rownames(mtcars_out)))
+    expect_true(all(rownames(mtcars_out) %in% mtcars_in$make_model))
+    expect_equal_df(unrowname(mtcars_out), mtcars_in[names(mtcars_in) != "make_model"])
   },
   #
   read_table_row_names_string_missing = function(ctx, con, table_name = "iris") {
-      #'   an error is raised if no such column exists.
-      row.names <- "missing"
+    #'   an error is raised if no such column exists.
+    row.names <- "missing"
 
-      iris_in <- get_iris(ctx)
-      dbWriteTable(con, "iris", iris_in, row.names = FALSE)
-      expect_error(dbReadTable(con, "iris", row.names = row.names))
+    iris_in <- get_iris(ctx)
+    dbWriteTable(con, "iris", iris_in, row.names = FALSE)
+    expect_error(dbReadTable(con, "iris", row.names = row.names))
   },
   #'
 
   read_table_row_names_default = function(con, table_name = "mtcars") {
-      #'
-      #' The default is `row.names = FALSE`.
-      #'
-      mtcars_in <- datasets::mtcars
-      dbWriteTable(con, "mtcars", mtcars_in, row.names = TRUE)
-      mtcars_out <- check_df(dbReadTable(con, "mtcars"))
+    #'
+    #' The default is `row.names = FALSE`.
+    #'
+    mtcars_in <- datasets::mtcars
+    dbWriteTable(con, "mtcars", mtcars_in, row.names = TRUE)
+    mtcars_out <- check_df(dbReadTable(con, "mtcars"))
 
-      expect_true("row_names" %in% names(mtcars_out))
-      expect_true(all(mtcars_out$row_names %in% rownames(mtcars_in)))
-      expect_true(all(rownames(mtcars_in) %in% mtcars_out$row_names))
-      expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
+    expect_true("row_names" %in% names(mtcars_out))
+    expect_true(all(mtcars_out$row_names %in% rownames(mtcars_in)))
+    expect_true(all(rownames(mtcars_in) %in% mtcars_out$row_names))
+    expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
   },
   #
   read_table_check_names = function(ctx, con, table_name = "test") {
-      #' If the database supports identifiers with special characters,
-      if (isTRUE(ctx$tweaks$strict_identifier)) {
-        skip("tweak: strict_identifier")
-      }
+    #' If the database supports identifiers with special characters,
+    if (isTRUE(ctx$tweaks$strict_identifier)) {
+      skip("tweak: strict_identifier")
+    }
 
-      #' the columns in the returned data frame are converted to valid R
-      #' identifiers
-      test_in <- data.frame(a = 1:3, b = 4:6)
-      names(test_in) <- c("with spaces", "with,comma")
-      dbWriteTable(con, "test", test_in)
-      #' if the `check.names` argument is `TRUE`,
-      test_out <- check_df(dbReadTable(con, "test", check.names = TRUE))
+    #' the columns in the returned data frame are converted to valid R
+    #' identifiers
+    test_in <- data.frame(a = 1:3, b = 4:6)
+    names(test_in) <- c("with spaces", "with,comma")
+    dbWriteTable(con, "test", test_in)
+    #' if the `check.names` argument is `TRUE`,
+    test_out <- check_df(dbReadTable(con, "test", check.names = TRUE))
 
-      expect_identical(names(test_out), make.names(names(test_out), unique = TRUE))
-      expect_equal_df(test_out, setNames(test_in, names(test_out)))
+    expect_identical(names(test_out), make.names(names(test_out), unique = TRUE))
+    expect_equal_df(test_out, setNames(test_in, names(test_out)))
   },
   #
   read_table_check_names_false = function(ctx, con, table_name = "test") {
-      if (isTRUE(ctx$tweaks$strict_identifier)) {
-        skip("tweak: strict_identifier")
-      }
+    if (isTRUE(ctx$tweaks$strict_identifier)) {
+      skip("tweak: strict_identifier")
+    }
 
-      #' If `check.names = FALSE`, the returned table has non-syntactic column names without quotes.
-      test_in <- data.frame(a = 1:3, b = 4:6)
-      names(test_in) <- c("with spaces", "with,comma")
-      dbWriteTable(con, "test", test_in)
-      test_out <- check_df(dbReadTable(con, "test", check.names = FALSE))
+    #' If `check.names = FALSE`, the returned table has non-syntactic column names without quotes.
+    test_in <- data.frame(a = 1:3, b = 4:6)
+    names(test_in) <- c("with spaces", "with,comma")
+    dbWriteTable(con, "test", test_in)
+    test_out <- check_df(dbReadTable(con, "test", check.names = FALSE))
 
-      expect_equal_df(test_out, test_in)
+    expect_equal_df(test_out, test_in)
   },
 
   #'
   #' An error is raised when calling this method for a closed
   read_table_closed_connection = function(ctx, con, table_name = "test") {
-      dbWriteTable(con, "test", data.frame(a = 1))
-      con2 <- local_closed_connection(ctx = ctx)
-      expect_error(dbReadTable(con2, "test"))
+    dbWriteTable(con, "test", data.frame(a = 1))
+    con2 <- local_closed_connection(ctx = ctx)
+    expect_error(dbReadTable(con2, "test"))
   },
 
   #' or invalid connection.
   read_table_invalid_connection = function(ctx, con, table_name = "test") {
-      dbWriteTable(con, "test", data.frame(a = 1))
-      con2 <- local_invalid_connection(ctx)
-      expect_error(dbReadTable(con2, "test"))
+    dbWriteTable(con, "test", data.frame(a = 1))
+    con2 <- local_invalid_connection(ctx)
+    expect_error(dbReadTable(con2, "test"))
   },
 
   #' An error is raised
   read_table_error = function(ctx, con, table_name = "test") {
-      dbWriteTable(con, "test", data.frame(a = 1L))
-      #' if `name` cannot be processed with [dbQuoteIdentifier()]
-      expect_error(dbReadTable(con, NA))
-      #' or if this results in a non-scalar.
-      expect_error(dbReadTable(con, c("test", "test")))
+    dbWriteTable(con, "test", data.frame(a = 1L))
+    #' if `name` cannot be processed with [dbQuoteIdentifier()]
+    expect_error(dbReadTable(con, NA))
+    #' or if this results in a non-scalar.
+    expect_error(dbReadTable(con, c("test", "test")))
 
-      #' Unsupported values for `row.names` and `check.names`
-      #' (non-scalars,
-      expect_error(dbReadTable(con, "test", row.names = letters))
-      #' unsupported data types,
-      expect_error(dbReadTable(con, "test", row.names = list(1L)))
-      expect_error(dbReadTable(con, "test", check.names = 1L))
-      #' `NA` for `check.names`)
-      expect_error(dbReadTable(con, "test", check.names = NA))
-      #' also raise an error.
+    #' Unsupported values for `row.names` and `check.names`
+    #' (non-scalars,
+    expect_error(dbReadTable(con, "test", row.names = letters))
+    #' unsupported data types,
+    expect_error(dbReadTable(con, "test", row.names = list(1L)))
+    expect_error(dbReadTable(con, "test", check.names = 1L))
+    #' `NA` for `check.names`)
+    expect_error(dbReadTable(con, "test", check.names = NA))
+    #' also raise an error.
   },
 
   #' @section Additional arguments:

--- a/R/spec-sql-read-table.R
+++ b/R/spec-sql-read-table.R
@@ -12,34 +12,28 @@ spec_sql_read_table <- list(
   #' `dbReadTable()` returns a data frame that contains the complete data
   #' from the remote table, effectively the result of calling [dbGetQuery()]
   #' with `SELECT * FROM <name>`.
-  read_table = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  read_table = function(ctx, con) with_remove_test_table(name = "iris", {
       iris_in <- get_iris(ctx)
       dbWriteTable(con, "iris", iris_in)
       iris_out <- check_df(dbReadTable(con, "iris"))
 
       expect_equal_df(iris_out, iris_in)
-    })
-  },
+  }), # with_remove_test_table
 
   #' An error is raised if the table does not exist.
-  read_table_missing = function(con) {
-    with_remove_test_table({
+  read_table_missing = function(con) with_remove_test_table({
       expect_error(dbReadTable(con, "test"))
-    })
-  },
+  }), # with_remove_test_table
 
   #' An empty table is returned as a data frame with zero rows.
-  read_table_empty = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  read_table_empty = function(ctx, con) with_remove_test_table(name = "iris", {
       iris_in <- get_iris(ctx)[integer(), ]
       dbWriteTable(con, "iris", iris_in)
       iris_out <- check_df(dbReadTable(con, "iris"))
 
       expect_equal(nrow(iris_out), 0L)
       expect_equal_df(iris_out, iris_in)
-    })
-  },
+  }), # with_remove_test_table
 
   #'
   #' The presence of [rownames] depends on the `row.names` argument,
@@ -60,8 +54,7 @@ spec_sql_read_table <- list(
     }
   },
   #
-  read_table_row_names_true_exists = function(con) {
-    with_remove_test_table(name = "mtcars", {
+  read_table_row_names_true_exists = function(con) with_remove_test_table(name = "mtcars", {
       #' - If `TRUE`, a column named "row_names" is converted to row names,
       row.names <- TRUE
 
@@ -70,22 +63,18 @@ spec_sql_read_table <- list(
       mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = row.names))
 
       expect_equal_df(mtcars_out, mtcars_in)
-    })
-  },
+  }), # with_remove_test_table
   #
-  read_table_row_names_true_missing = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  read_table_row_names_true_missing = function(ctx, con) with_remove_test_table(name = "iris", {
       #'   an error is raised if no such column exists.
       row.names <- TRUE
 
       iris_in <- get_iris(ctx)
       dbWriteTable(con, "iris", iris_in, row.names = NA)
       expect_error(dbReadTable(con, "iris", row.names = row.names))
-    })
-  },
+  }), # with_remove_test_table
   #
-  read_table_row_names_na_exists = function(con) {
-    with_remove_test_table(name = "mtcars", {
+  read_table_row_names_na_exists = function(con) with_remove_test_table(name = "mtcars", {
       #' - If `NA`, a column named "row_names" is converted to row names if it exists,
       row.names <- NA
 
@@ -94,11 +83,9 @@ spec_sql_read_table <- list(
       mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = row.names))
 
       expect_equal_df(mtcars_out, mtcars_in)
-    })
-  },
+  }), # with_remove_test_table
   #
-  read_table_row_names_na_missing = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  read_table_row_names_na_missing = function(ctx, con) with_remove_test_table(name = "iris", {
       #'   otherwise no translation occurs.
       row.names <- NA
 
@@ -107,11 +94,9 @@ spec_sql_read_table <- list(
       iris_out <- check_df(dbReadTable(con, "iris", row.names = row.names))
 
       expect_equal_df(iris_out, iris_in)
-    })
-  },
+  }), # with_remove_test_table
   #
-  read_table_row_names_string_exists = function(con) {
-    with_remove_test_table(name = "mtcars", {
+  read_table_row_names_string_exists = function(con) with_remove_test_table(name = "mtcars", {
       #' - If a string, this specifies the name of the column in the remote table
       #'   that contains the row names,
       row.names <- "make_model"
@@ -127,23 +112,19 @@ spec_sql_read_table <- list(
       expect_true(all(mtcars_in$make_model %in% rownames(mtcars_out)))
       expect_true(all(rownames(mtcars_out) %in% mtcars_in$make_model))
       expect_equal_df(unrowname(mtcars_out), mtcars_in[names(mtcars_in) != "make_model"])
-    })
-  },
+  }), # with_remove_test_table
   #
-  read_table_row_names_string_missing = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  read_table_row_names_string_missing = function(ctx, con) with_remove_test_table(name = "iris", {
       #'   an error is raised if no such column exists.
       row.names <- "missing"
 
       iris_in <- get_iris(ctx)
       dbWriteTable(con, "iris", iris_in, row.names = FALSE)
       expect_error(dbReadTable(con, "iris", row.names = row.names))
-    })
-  },
+  }), # with_remove_test_table
   #'
 
-  read_table_row_names_default = function(con) {
-    with_remove_test_table(name = "mtcars", {
+  read_table_row_names_default = function(con) with_remove_test_table(name = "mtcars", {
       #'
       #' The default is `row.names = FALSE`.
       #'
@@ -155,8 +136,7 @@ spec_sql_read_table <- list(
       expect_true(all(mtcars_out$row_names %in% rownames(mtcars_in)))
       expect_true(all(rownames(mtcars_in) %in% mtcars_out$row_names))
       expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
-    })
-  },
+  }), # with_remove_test_table
   #
   read_table_check_names = function(ctx, con) {
     #' If the database supports identifiers with special characters,
@@ -190,26 +170,21 @@ spec_sql_read_table <- list(
 
   #'
   #' An error is raised when calling this method for a closed
-  read_table_closed_connection = function(ctx, con) {
-    with_remove_test_table({
+  read_table_closed_connection = function(ctx, con) with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1))
       con2 <- local_closed_connection(ctx = ctx)
       expect_error(dbReadTable(con2, "test"))
-    })
-  },
+  }), # with_remove_test_table
 
   #' or invalid connection.
-  read_table_invalid_connection = function(ctx, con) {
-    with_remove_test_table({
+  read_table_invalid_connection = function(ctx, con) with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1))
       con2 <- local_invalid_connection(ctx)
       expect_error(dbReadTable(con2, "test"))
-    })
-  },
+  }), # with_remove_test_table
 
   #' An error is raised
-  read_table_error = function(ctx, con) {
-    with_remove_test_table({
+  read_table_error = function(ctx, con) with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1L))
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbReadTable(con, NA))
@@ -225,8 +200,7 @@ spec_sql_read_table <- list(
       #' `NA` for `check.names`)
       expect_error(dbReadTable(con, "test", check.names = NA))
       #' also raise an error.
-    })
-  },
+  }), # with_remove_test_table
 
   #' @section Additional arguments:
   #' The following arguments are not part of the `dbReadTable()` generic

--- a/R/spec-sql-read-table.R
+++ b/R/spec-sql-read-table.R
@@ -138,8 +138,7 @@ spec_sql_read_table <- list(
       expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
   }), # with_remove_test_table
   #
-  read_table_check_names = function(ctx, con) {
-    with_remove_test_table({
+  read_table_check_names = function(ctx, con) with_remove_test_table({
       #' If the database supports identifiers with special characters,
       if (isTRUE(ctx$tweaks$strict_identifier)) {
         skip("tweak: strict_identifier")
@@ -155,11 +154,9 @@ spec_sql_read_table <- list(
 
       expect_identical(names(test_out), make.names(names(test_out), unique = TRUE))
       expect_equal_df(test_out, setNames(test_in, names(test_out)))
-    })
-  },
+  }), # with_remove_test_table
   #
-  read_table_check_names_false = function(ctx, con) {
-    with_remove_test_table({
+  read_table_check_names_false = function(ctx, con) with_remove_test_table({
       if (isTRUE(ctx$tweaks$strict_identifier)) {
         skip("tweak: strict_identifier")
       }
@@ -171,8 +168,7 @@ spec_sql_read_table <- list(
       test_out <- check_df(dbReadTable(con, "test", check.names = FALSE))
 
       expect_equal_df(test_out, test_in)
-    })
-  },
+  }), # with_remove_test_table
 
   #'
   #' An error is raised when calling this method for a closed

--- a/R/spec-sql-read-table.R
+++ b/R/spec-sql-read-table.R
@@ -22,7 +22,7 @@ spec_sql_read_table <- list(
 
   #' An error is raised if the table does not exist.
   read_table_missing = function(con, table_name = "test") {
-    expect_error(dbReadTable(con, "test"))
+    expect_error(dbReadTable(con, table_name))
   },
 
   #' An empty table is returned as a data frame with zero rows.
@@ -148,9 +148,9 @@ spec_sql_read_table <- list(
     #' identifiers
     test_in <- data.frame(a = 1:3, b = 4:6)
     names(test_in) <- c("with spaces", "with,comma")
-    dbWriteTable(con, "test", test_in)
+    dbWriteTable(con, table_name, test_in)
     #' if the `check.names` argument is `TRUE`,
-    test_out <- check_df(dbReadTable(con, "test", check.names = TRUE))
+    test_out <- check_df(dbReadTable(con, table_name, check.names = TRUE))
 
     expect_identical(names(test_out), make.names(names(test_out), unique = TRUE))
     expect_equal_df(test_out, setNames(test_in, names(test_out)))
@@ -164,8 +164,8 @@ spec_sql_read_table <- list(
     #' If `check.names = FALSE`, the returned table has non-syntactic column names without quotes.
     test_in <- data.frame(a = 1:3, b = 4:6)
     names(test_in) <- c("with spaces", "with,comma")
-    dbWriteTable(con, "test", test_in)
-    test_out <- check_df(dbReadTable(con, "test", check.names = FALSE))
+    dbWriteTable(con, table_name, test_in)
+    test_out <- check_df(dbReadTable(con, table_name, check.names = FALSE))
 
     expect_equal_df(test_out, test_in)
   },
@@ -173,34 +173,34 @@ spec_sql_read_table <- list(
   #'
   #' An error is raised when calling this method for a closed
   read_table_closed_connection = function(ctx, con, table_name = "test") {
-    dbWriteTable(con, "test", data.frame(a = 1))
+    dbWriteTable(con, table_name, data.frame(a = 1))
     con2 <- local_closed_connection(ctx = ctx)
-    expect_error(dbReadTable(con2, "test"))
+    expect_error(dbReadTable(con2, table_name))
   },
 
   #' or invalid connection.
   read_table_invalid_connection = function(ctx, con, table_name = "test") {
-    dbWriteTable(con, "test", data.frame(a = 1))
+    dbWriteTable(con, table_name, data.frame(a = 1))
     con2 <- local_invalid_connection(ctx)
-    expect_error(dbReadTable(con2, "test"))
+    expect_error(dbReadTable(con2, table_name))
   },
 
   #' An error is raised
   read_table_error = function(ctx, con, table_name = "test") {
-    dbWriteTable(con, "test", data.frame(a = 1L))
+    dbWriteTable(con, table_name, data.frame(a = 1L))
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbReadTable(con, NA))
     #' or if this results in a non-scalar.
-    expect_error(dbReadTable(con, c("test", "test")))
+    expect_error(dbReadTable(con, c(table_name, table_name)))
 
     #' Unsupported values for `row.names` and `check.names`
     #' (non-scalars,
-    expect_error(dbReadTable(con, "test", row.names = letters))
+    expect_error(dbReadTable(con, table_name, row.names = letters))
     #' unsupported data types,
-    expect_error(dbReadTable(con, "test", row.names = list(1L)))
-    expect_error(dbReadTable(con, "test", check.names = 1L))
+    expect_error(dbReadTable(con, table_name, row.names = list(1L)))
+    expect_error(dbReadTable(con, table_name, check.names = 1L))
     #' `NA` for `check.names`)
-    expect_error(dbReadTable(con, "test", check.names = NA))
+    expect_error(dbReadTable(con, table_name, check.names = NA))
     #' also raise an error.
   },
 

--- a/R/spec-sql-read-table.R
+++ b/R/spec-sql-read-table.R
@@ -12,28 +12,28 @@ spec_sql_read_table <- list(
   #' `dbReadTable()` returns a data frame that contains the complete data
   #' from the remote table, effectively the result of calling [dbGetQuery()]
   #' with `SELECT * FROM <name>`.
-  read_table = function(ctx, con) with_remove_test_table(name = "iris", {
+  read_table = function(ctx, con, table_name = "iris") {
       iris_in <- get_iris(ctx)
       dbWriteTable(con, "iris", iris_in)
       iris_out <- check_df(dbReadTable(con, "iris"))
 
       expect_equal_df(iris_out, iris_in)
-  }), # with_remove_test_table
+  },
 
   #' An error is raised if the table does not exist.
-  read_table_missing = function(con) with_remove_test_table(name = "test", {
+  read_table_missing = function(con, table_name = "test") {
       expect_error(dbReadTable(con, "test"))
-  }), # with_remove_test_table
+  },
 
   #' An empty table is returned as a data frame with zero rows.
-  read_table_empty = function(ctx, con) with_remove_test_table(name = "iris", {
+  read_table_empty = function(ctx, con, table_name = "iris") {
       iris_in <- get_iris(ctx)[integer(), ]
       dbWriteTable(con, "iris", iris_in)
       iris_out <- check_df(dbReadTable(con, "iris"))
 
       expect_equal(nrow(iris_out), 0L)
       expect_equal_df(iris_out, iris_in)
-  }), # with_remove_test_table
+  },
 
   #'
   #' The presence of [rownames] depends on the `row.names` argument,
@@ -54,7 +54,7 @@ spec_sql_read_table <- list(
     }
   },
   #
-  read_table_row_names_true_exists = function(con) with_remove_test_table(name = "mtcars", {
+  read_table_row_names_true_exists = function(con, table_name = "mtcars") {
       #' - If `TRUE`, a column named "row_names" is converted to row names,
       row.names <- TRUE
 
@@ -63,18 +63,18 @@ spec_sql_read_table <- list(
       mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = row.names))
 
       expect_equal_df(mtcars_out, mtcars_in)
-  }), # with_remove_test_table
+  },
   #
-  read_table_row_names_true_missing = function(ctx, con) with_remove_test_table(name = "iris", {
+  read_table_row_names_true_missing = function(ctx, con, table_name = "iris") {
       #'   an error is raised if no such column exists.
       row.names <- TRUE
 
       iris_in <- get_iris(ctx)
       dbWriteTable(con, "iris", iris_in, row.names = NA)
       expect_error(dbReadTable(con, "iris", row.names = row.names))
-  }), # with_remove_test_table
+  },
   #
-  read_table_row_names_na_exists = function(con) with_remove_test_table(name = "mtcars", {
+  read_table_row_names_na_exists = function(con, table_name = "mtcars") {
       #' - If `NA`, a column named "row_names" is converted to row names if it exists,
       row.names <- NA
 
@@ -83,9 +83,9 @@ spec_sql_read_table <- list(
       mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = row.names))
 
       expect_equal_df(mtcars_out, mtcars_in)
-  }), # with_remove_test_table
+  },
   #
-  read_table_row_names_na_missing = function(ctx, con) with_remove_test_table(name = "iris", {
+  read_table_row_names_na_missing = function(ctx, con, table_name = "iris") {
       #'   otherwise no translation occurs.
       row.names <- NA
 
@@ -94,9 +94,9 @@ spec_sql_read_table <- list(
       iris_out <- check_df(dbReadTable(con, "iris", row.names = row.names))
 
       expect_equal_df(iris_out, iris_in)
-  }), # with_remove_test_table
+  },
   #
-  read_table_row_names_string_exists = function(con) with_remove_test_table(name = "mtcars", {
+  read_table_row_names_string_exists = function(con, table_name = "mtcars") {
       #' - If a string, this specifies the name of the column in the remote table
       #'   that contains the row names,
       row.names <- "make_model"
@@ -112,19 +112,19 @@ spec_sql_read_table <- list(
       expect_true(all(mtcars_in$make_model %in% rownames(mtcars_out)))
       expect_true(all(rownames(mtcars_out) %in% mtcars_in$make_model))
       expect_equal_df(unrowname(mtcars_out), mtcars_in[names(mtcars_in) != "make_model"])
-  }), # with_remove_test_table
+  },
   #
-  read_table_row_names_string_missing = function(ctx, con) with_remove_test_table(name = "iris", {
+  read_table_row_names_string_missing = function(ctx, con, table_name = "iris") {
       #'   an error is raised if no such column exists.
       row.names <- "missing"
 
       iris_in <- get_iris(ctx)
       dbWriteTable(con, "iris", iris_in, row.names = FALSE)
       expect_error(dbReadTable(con, "iris", row.names = row.names))
-  }), # with_remove_test_table
+  },
   #'
 
-  read_table_row_names_default = function(con) with_remove_test_table(name = "mtcars", {
+  read_table_row_names_default = function(con, table_name = "mtcars") {
       #'
       #' The default is `row.names = FALSE`.
       #'
@@ -136,9 +136,9 @@ spec_sql_read_table <- list(
       expect_true(all(mtcars_out$row_names %in% rownames(mtcars_in)))
       expect_true(all(rownames(mtcars_in) %in% mtcars_out$row_names))
       expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
-  }), # with_remove_test_table
+  },
   #
-  read_table_check_names = function(ctx, con) with_remove_test_table(name = "test", {
+  read_table_check_names = function(ctx, con, table_name = "test") {
       #' If the database supports identifiers with special characters,
       if (isTRUE(ctx$tweaks$strict_identifier)) {
         skip("tweak: strict_identifier")
@@ -154,9 +154,9 @@ spec_sql_read_table <- list(
 
       expect_identical(names(test_out), make.names(names(test_out), unique = TRUE))
       expect_equal_df(test_out, setNames(test_in, names(test_out)))
-  }), # with_remove_test_table
+  },
   #
-  read_table_check_names_false = function(ctx, con) with_remove_test_table(name = "test", {
+  read_table_check_names_false = function(ctx, con, table_name = "test") {
       if (isTRUE(ctx$tweaks$strict_identifier)) {
         skip("tweak: strict_identifier")
       }
@@ -168,25 +168,25 @@ spec_sql_read_table <- list(
       test_out <- check_df(dbReadTable(con, "test", check.names = FALSE))
 
       expect_equal_df(test_out, test_in)
-  }), # with_remove_test_table
+  },
 
   #'
   #' An error is raised when calling this method for a closed
-  read_table_closed_connection = function(ctx, con) with_remove_test_table(name = "test", {
+  read_table_closed_connection = function(ctx, con, table_name = "test") {
       dbWriteTable(con, "test", data.frame(a = 1))
       con2 <- local_closed_connection(ctx = ctx)
       expect_error(dbReadTable(con2, "test"))
-  }), # with_remove_test_table
+  },
 
   #' or invalid connection.
-  read_table_invalid_connection = function(ctx, con) with_remove_test_table(name = "test", {
+  read_table_invalid_connection = function(ctx, con, table_name = "test") {
       dbWriteTable(con, "test", data.frame(a = 1))
       con2 <- local_invalid_connection(ctx)
       expect_error(dbReadTable(con2, "test"))
-  }), # with_remove_test_table
+  },
 
   #' An error is raised
-  read_table_error = function(ctx, con) with_remove_test_table(name = "test", {
+  read_table_error = function(ctx, con, table_name = "test") {
       dbWriteTable(con, "test", data.frame(a = 1L))
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbReadTable(con, NA))
@@ -202,7 +202,7 @@ spec_sql_read_table <- list(
       #' `NA` for `check.names`)
       expect_error(dbReadTable(con, "test", check.names = NA))
       #' also raise an error.
-  }), # with_remove_test_table
+  },
 
   #' @section Additional arguments:
   #' The following arguments are not part of the `dbReadTable()` generic

--- a/R/spec-sql-read-table.R
+++ b/R/spec-sql-read-table.R
@@ -21,7 +21,7 @@ spec_sql_read_table <- list(
   }), # with_remove_test_table
 
   #' An error is raised if the table does not exist.
-  read_table_missing = function(con) with_remove_test_table({
+  read_table_missing = function(con) with_remove_test_table(name = "test", {
       expect_error(dbReadTable(con, "test"))
   }), # with_remove_test_table
 
@@ -138,7 +138,7 @@ spec_sql_read_table <- list(
       expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
   }), # with_remove_test_table
   #
-  read_table_check_names = function(ctx, con) with_remove_test_table({
+  read_table_check_names = function(ctx, con) with_remove_test_table(name = "test", {
       #' If the database supports identifiers with special characters,
       if (isTRUE(ctx$tweaks$strict_identifier)) {
         skip("tweak: strict_identifier")
@@ -156,7 +156,7 @@ spec_sql_read_table <- list(
       expect_equal_df(test_out, setNames(test_in, names(test_out)))
   }), # with_remove_test_table
   #
-  read_table_check_names_false = function(ctx, con) with_remove_test_table({
+  read_table_check_names_false = function(ctx, con) with_remove_test_table(name = "test", {
       if (isTRUE(ctx$tweaks$strict_identifier)) {
         skip("tweak: strict_identifier")
       }
@@ -172,21 +172,21 @@ spec_sql_read_table <- list(
 
   #'
   #' An error is raised when calling this method for a closed
-  read_table_closed_connection = function(ctx, con) with_remove_test_table({
+  read_table_closed_connection = function(ctx, con) with_remove_test_table(name = "test", {
       dbWriteTable(con, "test", data.frame(a = 1))
       con2 <- local_closed_connection(ctx = ctx)
       expect_error(dbReadTable(con2, "test"))
   }), # with_remove_test_table
 
   #' or invalid connection.
-  read_table_invalid_connection = function(ctx, con) with_remove_test_table({
+  read_table_invalid_connection = function(ctx, con) with_remove_test_table(name = "test", {
       dbWriteTable(con, "test", data.frame(a = 1))
       con2 <- local_invalid_connection(ctx)
       expect_error(dbReadTable(con2, "test"))
   }), # with_remove_test_table
 
   #' An error is raised
-  read_table_error = function(ctx, con) with_remove_test_table({
+  read_table_error = function(ctx, con) with_remove_test_table(name = "test", {
       dbWriteTable(con, "test", data.frame(a = 1L))
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbReadTable(con, NA))

--- a/R/spec-sql-remove-table.R
+++ b/R/spec-sql-remove-table.R
@@ -10,53 +10,43 @@ spec_sql_remove_table <- list(
 
   #' @return
   #' `dbRemoveTable()` returns `TRUE`, invisibly.
-  remove_table_return = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  remove_table_return = function(ctx, con) with_remove_test_table(name = "iris", {
       iris <- get_iris(ctx)
       dbWriteTable(con, "iris", iris)
 
       expect_invisible_true(dbRemoveTable(con, "iris"))
-    })
-  },
+  }), # with_remove_test_table
 
   #' If the table does not exist, an error is raised.
-  remove_table_missing = function(con) {
-    with_remove_test_table({
+  remove_table_missing = function(con) with_remove_test_table({
       expect_error(dbRemoveTable(con, "test"))
-    })
-  },
+  }), # with_remove_test_table
 
   #' An attempt to remove a view with this function may result in an error.
   #'
   #'
   #' An error is raised when calling this method for a closed
-  remove_table_closed_connection = function(ctx, con) {
-    with_remove_test_table({
+  remove_table_closed_connection = function(ctx, con) with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1))
       con2 <- local_closed_connection(ctx = ctx)
       expect_error(dbRemoveTable(con2, "test"))
-    })
-  },
+  }), # with_remove_test_table
 
   #' or invalid connection.
-  remove_table_invalid_connection = function(ctx, con) {
-    with_remove_test_table({
+  remove_table_invalid_connection = function(ctx, con) with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1))
       con2 <- local_invalid_connection(ctx)
       expect_error(dbRemoveTable(con2, "test"))
-    })
-  },
+  }), # with_remove_test_table
 
   #' An error is also raised
-  remove_table_error = function(con) {
-    with_remove_test_table({
+  remove_table_error = function(con) with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1L))
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbRemoveTable(con, NA))
       #' or if this results in a non-scalar.
       expect_error(dbRemoveTable(con, c("test", "test")))
-    })
-  },
+  }), # with_remove_test_table
 
   #' @section Additional arguments:
   #' The following arguments are not part of the `dbRemoveTable()` generic
@@ -71,8 +61,7 @@ spec_sql_remove_table <- list(
   #'
   #' If `temporary` is `TRUE`, the call to `dbRemoveTable()`
   #' will consider only temporary tables.
-  remove_table_temporary_arg = function(ctx, con) {
-    with_remove_test_table({
+  remove_table_temporary_arg = function(ctx, con) with_remove_test_table({
       #' Not all backends support this argument.
       if (!isTRUE(ctx$tweaks$temporary_tables)) {
         skip("tweak: temporary_tables")
@@ -85,24 +74,20 @@ spec_sql_remove_table <- list(
       #' In particular, permanent tables of the same name are left untouched.
       expect_error(dbRemoveTable(con, "test", temporary = TRUE))
       expect_equal(dbReadTable(con, "test"), data.frame(a = 1.5))
-    })
-  },
+  }), # with_remove_test_table
 
   #'
   #' If `fail_if_missing` is `FALSE`, the call to `dbRemoveTable()`
   #' succeeds if the table does not exist.
-  remove_table_missing_succeed = function(con) {
-    with_remove_test_table({
+  remove_table_missing_succeed = function(con) with_remove_test_table({
       expect_error(dbRemoveTable(con, "test", fail_if_missing = FALSE), NA)
-    })
-  },
+  }), # with_remove_test_table
 
   #' @section Specification:
   #' A table removed by `dbRemoveTable()` doesn't appear in the list of tables
   #' returned by [dbListTables()],
   #' and [dbExistsTable()] returns `FALSE`.
-  remove_table_list = function(con) {
-    with_remove_test_table({
+  remove_table_list = function(con) with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 1L))
       expect_true("test" %in% dbListTables(con))
       expect_true(dbExistsTable(con, "test"))
@@ -110,12 +95,10 @@ spec_sql_remove_table <- list(
       dbRemoveTable(con, "test")
       expect_false("test" %in% dbListTables(con))
       expect_false(dbExistsTable(con, "test"))
-    })
-  },
+  }), # with_remove_test_table
 
   #' The removal propagates immediately to other connections to the same database.
-  remove_table_other_con = function(ctx, con) {
-    with_remove_test_table({
+  remove_table_other_con = function(ctx, con) with_remove_test_table({
       con2 <- local_connection(ctx)
       dbWriteTable(con, "test", data.frame(a = 1L))
       expect_true("test" %in% dbListTables(con2))
@@ -124,12 +107,10 @@ spec_sql_remove_table <- list(
       dbRemoveTable(con, "test")
       expect_false("test" %in% dbListTables(con2))
       expect_false(dbExistsTable(con2, "test"))
-    })
-  },
+  }), # with_remove_test_table
 
   #' This function can also be used to remove a temporary table.
-  remove_table_temporary = function(ctx, con) {
-    with_remove_test_table({
+  remove_table_temporary = function(ctx, con) with_remove_test_table({
       if (!isTRUE(ctx$tweaks$temporary_tables)) {
         skip("tweak: temporary_tables")
       }
@@ -145,8 +126,7 @@ spec_sql_remove_table <- list(
         expect_false("test" %in% dbListTables(con))
       }
       expect_false(dbExistsTable(con, "test"))
-    })
-  },
+  }), # with_remove_test_table
 
   #'
   #' The `name` argument is processed as follows,

--- a/R/spec-sql-remove-table.R
+++ b/R/spec-sql-remove-table.R
@@ -18,7 +18,7 @@ spec_sql_remove_table <- list(
   }), # with_remove_test_table
 
   #' If the table does not exist, an error is raised.
-  remove_table_missing = function(con) with_remove_test_table({
+  remove_table_missing = function(con) with_remove_test_table(name = "test", {
       expect_error(dbRemoveTable(con, "test"))
   }), # with_remove_test_table
 
@@ -26,21 +26,21 @@ spec_sql_remove_table <- list(
   #'
   #'
   #' An error is raised when calling this method for a closed
-  remove_table_closed_connection = function(ctx, con) with_remove_test_table({
+  remove_table_closed_connection = function(ctx, con) with_remove_test_table(name = "test", {
       dbWriteTable(con, "test", data.frame(a = 1))
       con2 <- local_closed_connection(ctx = ctx)
       expect_error(dbRemoveTable(con2, "test"))
   }), # with_remove_test_table
 
   #' or invalid connection.
-  remove_table_invalid_connection = function(ctx, con) with_remove_test_table({
+  remove_table_invalid_connection = function(ctx, con) with_remove_test_table(name = "test", {
       dbWriteTable(con, "test", data.frame(a = 1))
       con2 <- local_invalid_connection(ctx)
       expect_error(dbRemoveTable(con2, "test"))
   }), # with_remove_test_table
 
   #' An error is also raised
-  remove_table_error = function(con) with_remove_test_table({
+  remove_table_error = function(con) with_remove_test_table(name = "test", {
       dbWriteTable(con, "test", data.frame(a = 1L))
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbRemoveTable(con, NA))
@@ -61,7 +61,7 @@ spec_sql_remove_table <- list(
   #'
   #' If `temporary` is `TRUE`, the call to `dbRemoveTable()`
   #' will consider only temporary tables.
-  remove_table_temporary_arg = function(ctx, con) with_remove_test_table({
+  remove_table_temporary_arg = function(ctx, con) with_remove_test_table(name = "test", {
       #' Not all backends support this argument.
       if (!isTRUE(ctx$tweaks$temporary_tables)) {
         skip("tweak: temporary_tables")
@@ -79,7 +79,7 @@ spec_sql_remove_table <- list(
   #'
   #' If `fail_if_missing` is `FALSE`, the call to `dbRemoveTable()`
   #' succeeds if the table does not exist.
-  remove_table_missing_succeed = function(con) with_remove_test_table({
+  remove_table_missing_succeed = function(con) with_remove_test_table(name = "test", {
       expect_error(dbRemoveTable(con, "test", fail_if_missing = FALSE), NA)
   }), # with_remove_test_table
 
@@ -87,7 +87,7 @@ spec_sql_remove_table <- list(
   #' A table removed by `dbRemoveTable()` doesn't appear in the list of tables
   #' returned by [dbListTables()],
   #' and [dbExistsTable()] returns `FALSE`.
-  remove_table_list = function(con) with_remove_test_table({
+  remove_table_list = function(con) with_remove_test_table(name = "test", {
       dbWriteTable(con, "test", data.frame(a = 1L))
       expect_true("test" %in% dbListTables(con))
       expect_true(dbExistsTable(con, "test"))
@@ -98,7 +98,7 @@ spec_sql_remove_table <- list(
   }), # with_remove_test_table
 
   #' The removal propagates immediately to other connections to the same database.
-  remove_table_other_con = function(ctx, con) with_remove_test_table({
+  remove_table_other_con = function(ctx, con) with_remove_test_table(name = "test", {
       con2 <- local_connection(ctx)
       dbWriteTable(con, "test", data.frame(a = 1L))
       expect_true("test" %in% dbListTables(con2))
@@ -110,7 +110,7 @@ spec_sql_remove_table <- list(
   }), # with_remove_test_table
 
   #' This function can also be used to remove a temporary table.
-  remove_table_temporary = function(ctx, con) with_remove_test_table({
+  remove_table_temporary = function(ctx, con) with_remove_test_table(name = "test", {
       if (!isTRUE(ctx$tweaks$temporary_tables)) {
         skip("tweak: temporary_tables")
       }

--- a/R/spec-sql-remove-table.R
+++ b/R/spec-sql-remove-table.R
@@ -19,7 +19,7 @@ spec_sql_remove_table <- list(
 
   #' If the table does not exist, an error is raised.
   remove_table_missing = function(con, table_name = "test") {
-    expect_error(dbRemoveTable(con, "test"))
+    expect_error(dbRemoveTable(con, table_name))
   },
 
   #' An attempt to remove a view with this function may result in an error.
@@ -27,25 +27,25 @@ spec_sql_remove_table <- list(
   #'
   #' An error is raised when calling this method for a closed
   remove_table_closed_connection = function(ctx, con, table_name = "test") {
-    dbWriteTable(con, "test", data.frame(a = 1))
+    dbWriteTable(con, table_name, data.frame(a = 1))
     con2 <- local_closed_connection(ctx = ctx)
-    expect_error(dbRemoveTable(con2, "test"))
+    expect_error(dbRemoveTable(con2, table_name))
   },
 
   #' or invalid connection.
   remove_table_invalid_connection = function(ctx, con, table_name = "test") {
-    dbWriteTable(con, "test", data.frame(a = 1))
+    dbWriteTable(con, table_name, data.frame(a = 1))
     con2 <- local_invalid_connection(ctx)
-    expect_error(dbRemoveTable(con2, "test"))
+    expect_error(dbRemoveTable(con2, table_name))
   },
 
   #' An error is also raised
   remove_table_error = function(con, table_name = "test") {
-    dbWriteTable(con, "test", data.frame(a = 1L))
+    dbWriteTable(con, table_name, data.frame(a = 1L))
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbRemoveTable(con, NA))
     #' or if this results in a non-scalar.
-    expect_error(dbRemoveTable(con, c("test", "test")))
+    expect_error(dbRemoveTable(con, c(table_name, table_name)))
   },
 
   #' @section Additional arguments:
@@ -67,20 +67,20 @@ spec_sql_remove_table <- list(
       skip("tweak: temporary_tables")
     }
 
-    dbWriteTable(con, "test", data.frame(a = 1.5))
-    expect_equal(dbReadTable(con, "test"), data.frame(a = 1.5))
-    dbCreateTable(con, "test", data.frame(b = 2.5), temporary = TRUE)
-    dbRemoveTable(con, "test", temporary = TRUE)
+    dbWriteTable(con, table_name, data.frame(a = 1.5))
+    expect_equal(dbReadTable(con, table_name), data.frame(a = 1.5))
+    dbCreateTable(con, table_name, data.frame(b = 2.5), temporary = TRUE)
+    dbRemoveTable(con, table_name, temporary = TRUE)
     #' In particular, permanent tables of the same name are left untouched.
-    expect_error(dbRemoveTable(con, "test", temporary = TRUE))
-    expect_equal(dbReadTable(con, "test"), data.frame(a = 1.5))
+    expect_error(dbRemoveTable(con, table_name, temporary = TRUE))
+    expect_equal(dbReadTable(con, table_name), data.frame(a = 1.5))
   },
 
   #'
   #' If `fail_if_missing` is `FALSE`, the call to `dbRemoveTable()`
   #' succeeds if the table does not exist.
   remove_table_missing_succeed = function(con, table_name = "test") {
-    expect_error(dbRemoveTable(con, "test", fail_if_missing = FALSE), NA)
+    expect_error(dbRemoveTable(con, table_name, fail_if_missing = FALSE), NA)
   },
 
   #' @section Specification:
@@ -88,25 +88,25 @@ spec_sql_remove_table <- list(
   #' returned by [dbListTables()],
   #' and [dbExistsTable()] returns `FALSE`.
   remove_table_list = function(con, table_name = "test") {
-    dbWriteTable(con, "test", data.frame(a = 1L))
-    expect_true("test" %in% dbListTables(con))
-    expect_true(dbExistsTable(con, "test"))
+    dbWriteTable(con, table_name, data.frame(a = 1L))
+    expect_true(table_name %in% dbListTables(con))
+    expect_true(dbExistsTable(con, table_name))
 
-    dbRemoveTable(con, "test")
-    expect_false("test" %in% dbListTables(con))
-    expect_false(dbExistsTable(con, "test"))
+    dbRemoveTable(con, table_name)
+    expect_false(table_name %in% dbListTables(con))
+    expect_false(dbExistsTable(con, table_name))
   },
 
   #' The removal propagates immediately to other connections to the same database.
   remove_table_other_con = function(ctx, con, table_name = "test") {
     con2 <- local_connection(ctx)
-    dbWriteTable(con, "test", data.frame(a = 1L))
-    expect_true("test" %in% dbListTables(con2))
-    expect_true(dbExistsTable(con2, "test"))
+    dbWriteTable(con, table_name, data.frame(a = 1L))
+    expect_true(table_name %in% dbListTables(con2))
+    expect_true(dbExistsTable(con2, table_name))
 
-    dbRemoveTable(con, "test")
-    expect_false("test" %in% dbListTables(con2))
-    expect_false(dbExistsTable(con2, "test"))
+    dbRemoveTable(con, table_name)
+    expect_false(table_name %in% dbListTables(con2))
+    expect_false(dbExistsTable(con2, table_name))
   },
 
   #' This function can also be used to remove a temporary table.
@@ -115,17 +115,17 @@ spec_sql_remove_table <- list(
       skip("tweak: temporary_tables")
     }
 
-    dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
+    dbWriteTable(con, table_name, data.frame(a = 1L), temporary = TRUE)
     if (isTRUE(ctx$tweaks$list_temporary_tables)) {
-      expect_true("test" %in% dbListTables(con))
+      expect_true(table_name %in% dbListTables(con))
     }
-    expect_true(dbExistsTable(con, "test"))
+    expect_true(dbExistsTable(con, table_name))
 
-    dbRemoveTable(con, "test")
+    dbRemoveTable(con, table_name)
     if (isTRUE(ctx$tweaks$list_temporary_tables)) {
-      expect_false("test" %in% dbListTables(con))
+      expect_false(table_name %in% dbListTables(con))
     }
-    expect_false(dbExistsTable(con, "test"))
+    expect_false(dbExistsTable(con, table_name))
   },
 
   #'

--- a/R/spec-sql-remove-table.R
+++ b/R/spec-sql-remove-table.R
@@ -11,15 +11,15 @@ spec_sql_remove_table <- list(
   #' @return
   #' `dbRemoveTable()` returns `TRUE`, invisibly.
   remove_table_return = function(ctx, con, table_name = "iris") {
-      iris <- get_iris(ctx)
-      dbWriteTable(con, "iris", iris)
+    iris <- get_iris(ctx)
+    dbWriteTable(con, "iris", iris)
 
-      expect_invisible_true(dbRemoveTable(con, "iris"))
+    expect_invisible_true(dbRemoveTable(con, "iris"))
   },
 
   #' If the table does not exist, an error is raised.
   remove_table_missing = function(con, table_name = "test") {
-      expect_error(dbRemoveTable(con, "test"))
+    expect_error(dbRemoveTable(con, "test"))
   },
 
   #' An attempt to remove a view with this function may result in an error.
@@ -27,25 +27,25 @@ spec_sql_remove_table <- list(
   #'
   #' An error is raised when calling this method for a closed
   remove_table_closed_connection = function(ctx, con, table_name = "test") {
-      dbWriteTable(con, "test", data.frame(a = 1))
-      con2 <- local_closed_connection(ctx = ctx)
-      expect_error(dbRemoveTable(con2, "test"))
+    dbWriteTable(con, "test", data.frame(a = 1))
+    con2 <- local_closed_connection(ctx = ctx)
+    expect_error(dbRemoveTable(con2, "test"))
   },
 
   #' or invalid connection.
   remove_table_invalid_connection = function(ctx, con, table_name = "test") {
-      dbWriteTable(con, "test", data.frame(a = 1))
-      con2 <- local_invalid_connection(ctx)
-      expect_error(dbRemoveTable(con2, "test"))
+    dbWriteTable(con, "test", data.frame(a = 1))
+    con2 <- local_invalid_connection(ctx)
+    expect_error(dbRemoveTable(con2, "test"))
   },
 
   #' An error is also raised
   remove_table_error = function(con, table_name = "test") {
-      dbWriteTable(con, "test", data.frame(a = 1L))
-      #' if `name` cannot be processed with [dbQuoteIdentifier()]
-      expect_error(dbRemoveTable(con, NA))
-      #' or if this results in a non-scalar.
-      expect_error(dbRemoveTable(con, c("test", "test")))
+    dbWriteTable(con, "test", data.frame(a = 1L))
+    #' if `name` cannot be processed with [dbQuoteIdentifier()]
+    expect_error(dbRemoveTable(con, NA))
+    #' or if this results in a non-scalar.
+    expect_error(dbRemoveTable(con, c("test", "test")))
   },
 
   #' @section Additional arguments:
@@ -62,25 +62,25 @@ spec_sql_remove_table <- list(
   #' If `temporary` is `TRUE`, the call to `dbRemoveTable()`
   #' will consider only temporary tables.
   remove_table_temporary_arg = function(ctx, con, table_name = "test") {
-      #' Not all backends support this argument.
-      if (!isTRUE(ctx$tweaks$temporary_tables)) {
-        skip("tweak: temporary_tables")
-      }
+    #' Not all backends support this argument.
+    if (!isTRUE(ctx$tweaks$temporary_tables)) {
+      skip("tweak: temporary_tables")
+    }
 
-      dbWriteTable(con, "test", data.frame(a = 1.5))
-      expect_equal(dbReadTable(con, "test"), data.frame(a = 1.5))
-      dbCreateTable(con, "test", data.frame(b = 2.5), temporary = TRUE)
-      dbRemoveTable(con, "test", temporary = TRUE)
-      #' In particular, permanent tables of the same name are left untouched.
-      expect_error(dbRemoveTable(con, "test", temporary = TRUE))
-      expect_equal(dbReadTable(con, "test"), data.frame(a = 1.5))
+    dbWriteTable(con, "test", data.frame(a = 1.5))
+    expect_equal(dbReadTable(con, "test"), data.frame(a = 1.5))
+    dbCreateTable(con, "test", data.frame(b = 2.5), temporary = TRUE)
+    dbRemoveTable(con, "test", temporary = TRUE)
+    #' In particular, permanent tables of the same name are left untouched.
+    expect_error(dbRemoveTable(con, "test", temporary = TRUE))
+    expect_equal(dbReadTable(con, "test"), data.frame(a = 1.5))
   },
 
   #'
   #' If `fail_if_missing` is `FALSE`, the call to `dbRemoveTable()`
   #' succeeds if the table does not exist.
   remove_table_missing_succeed = function(con, table_name = "test") {
-      expect_error(dbRemoveTable(con, "test", fail_if_missing = FALSE), NA)
+    expect_error(dbRemoveTable(con, "test", fail_if_missing = FALSE), NA)
   },
 
   #' @section Specification:
@@ -88,44 +88,44 @@ spec_sql_remove_table <- list(
   #' returned by [dbListTables()],
   #' and [dbExistsTable()] returns `FALSE`.
   remove_table_list = function(con, table_name = "test") {
-      dbWriteTable(con, "test", data.frame(a = 1L))
-      expect_true("test" %in% dbListTables(con))
-      expect_true(dbExistsTable(con, "test"))
+    dbWriteTable(con, "test", data.frame(a = 1L))
+    expect_true("test" %in% dbListTables(con))
+    expect_true(dbExistsTable(con, "test"))
 
-      dbRemoveTable(con, "test")
-      expect_false("test" %in% dbListTables(con))
-      expect_false(dbExistsTable(con, "test"))
+    dbRemoveTable(con, "test")
+    expect_false("test" %in% dbListTables(con))
+    expect_false(dbExistsTable(con, "test"))
   },
 
   #' The removal propagates immediately to other connections to the same database.
   remove_table_other_con = function(ctx, con, table_name = "test") {
-      con2 <- local_connection(ctx)
-      dbWriteTable(con, "test", data.frame(a = 1L))
-      expect_true("test" %in% dbListTables(con2))
-      expect_true(dbExistsTable(con2, "test"))
+    con2 <- local_connection(ctx)
+    dbWriteTable(con, "test", data.frame(a = 1L))
+    expect_true("test" %in% dbListTables(con2))
+    expect_true(dbExistsTable(con2, "test"))
 
-      dbRemoveTable(con, "test")
-      expect_false("test" %in% dbListTables(con2))
-      expect_false(dbExistsTable(con2, "test"))
+    dbRemoveTable(con, "test")
+    expect_false("test" %in% dbListTables(con2))
+    expect_false(dbExistsTable(con2, "test"))
   },
 
   #' This function can also be used to remove a temporary table.
   remove_table_temporary = function(ctx, con, table_name = "test") {
-      if (!isTRUE(ctx$tweaks$temporary_tables)) {
-        skip("tweak: temporary_tables")
-      }
+    if (!isTRUE(ctx$tweaks$temporary_tables)) {
+      skip("tweak: temporary_tables")
+    }
 
-      dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
-      if (isTRUE(ctx$tweaks$list_temporary_tables)) {
-        expect_true("test" %in% dbListTables(con))
-      }
-      expect_true(dbExistsTable(con, "test"))
+    dbWriteTable(con, "test", data.frame(a = 1L), temporary = TRUE)
+    if (isTRUE(ctx$tweaks$list_temporary_tables)) {
+      expect_true("test" %in% dbListTables(con))
+    }
+    expect_true(dbExistsTable(con, "test"))
 
-      dbRemoveTable(con, "test")
-      if (isTRUE(ctx$tweaks$list_temporary_tables)) {
-        expect_false("test" %in% dbListTables(con))
-      }
-      expect_false(dbExistsTable(con, "test"))
+    dbRemoveTable(con, "test")
+    if (isTRUE(ctx$tweaks$list_temporary_tables)) {
+      expect_false("test" %in% dbListTables(con))
+    }
+    expect_false(dbExistsTable(con, "test"))
   },
 
   #'

--- a/R/spec-sql-remove-table.R
+++ b/R/spec-sql-remove-table.R
@@ -10,43 +10,43 @@ spec_sql_remove_table <- list(
 
   #' @return
   #' `dbRemoveTable()` returns `TRUE`, invisibly.
-  remove_table_return = function(ctx, con) with_remove_test_table(name = "iris", {
+  remove_table_return = function(ctx, con, table_name = "iris") {
       iris <- get_iris(ctx)
       dbWriteTable(con, "iris", iris)
 
       expect_invisible_true(dbRemoveTable(con, "iris"))
-  }), # with_remove_test_table
+  },
 
   #' If the table does not exist, an error is raised.
-  remove_table_missing = function(con) with_remove_test_table(name = "test", {
+  remove_table_missing = function(con, table_name = "test") {
       expect_error(dbRemoveTable(con, "test"))
-  }), # with_remove_test_table
+  },
 
   #' An attempt to remove a view with this function may result in an error.
   #'
   #'
   #' An error is raised when calling this method for a closed
-  remove_table_closed_connection = function(ctx, con) with_remove_test_table(name = "test", {
+  remove_table_closed_connection = function(ctx, con, table_name = "test") {
       dbWriteTable(con, "test", data.frame(a = 1))
       con2 <- local_closed_connection(ctx = ctx)
       expect_error(dbRemoveTable(con2, "test"))
-  }), # with_remove_test_table
+  },
 
   #' or invalid connection.
-  remove_table_invalid_connection = function(ctx, con) with_remove_test_table(name = "test", {
+  remove_table_invalid_connection = function(ctx, con, table_name = "test") {
       dbWriteTable(con, "test", data.frame(a = 1))
       con2 <- local_invalid_connection(ctx)
       expect_error(dbRemoveTable(con2, "test"))
-  }), # with_remove_test_table
+  },
 
   #' An error is also raised
-  remove_table_error = function(con) with_remove_test_table(name = "test", {
+  remove_table_error = function(con, table_name = "test") {
       dbWriteTable(con, "test", data.frame(a = 1L))
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbRemoveTable(con, NA))
       #' or if this results in a non-scalar.
       expect_error(dbRemoveTable(con, c("test", "test")))
-  }), # with_remove_test_table
+  },
 
   #' @section Additional arguments:
   #' The following arguments are not part of the `dbRemoveTable()` generic
@@ -61,7 +61,7 @@ spec_sql_remove_table <- list(
   #'
   #' If `temporary` is `TRUE`, the call to `dbRemoveTable()`
   #' will consider only temporary tables.
-  remove_table_temporary_arg = function(ctx, con) with_remove_test_table(name = "test", {
+  remove_table_temporary_arg = function(ctx, con, table_name = "test") {
       #' Not all backends support this argument.
       if (!isTRUE(ctx$tweaks$temporary_tables)) {
         skip("tweak: temporary_tables")
@@ -74,20 +74,20 @@ spec_sql_remove_table <- list(
       #' In particular, permanent tables of the same name are left untouched.
       expect_error(dbRemoveTable(con, "test", temporary = TRUE))
       expect_equal(dbReadTable(con, "test"), data.frame(a = 1.5))
-  }), # with_remove_test_table
+  },
 
   #'
   #' If `fail_if_missing` is `FALSE`, the call to `dbRemoveTable()`
   #' succeeds if the table does not exist.
-  remove_table_missing_succeed = function(con) with_remove_test_table(name = "test", {
+  remove_table_missing_succeed = function(con, table_name = "test") {
       expect_error(dbRemoveTable(con, "test", fail_if_missing = FALSE), NA)
-  }), # with_remove_test_table
+  },
 
   #' @section Specification:
   #' A table removed by `dbRemoveTable()` doesn't appear in the list of tables
   #' returned by [dbListTables()],
   #' and [dbExistsTable()] returns `FALSE`.
-  remove_table_list = function(con) with_remove_test_table(name = "test", {
+  remove_table_list = function(con, table_name = "test") {
       dbWriteTable(con, "test", data.frame(a = 1L))
       expect_true("test" %in% dbListTables(con))
       expect_true(dbExistsTable(con, "test"))
@@ -95,10 +95,10 @@ spec_sql_remove_table <- list(
       dbRemoveTable(con, "test")
       expect_false("test" %in% dbListTables(con))
       expect_false(dbExistsTable(con, "test"))
-  }), # with_remove_test_table
+  },
 
   #' The removal propagates immediately to other connections to the same database.
-  remove_table_other_con = function(ctx, con) with_remove_test_table(name = "test", {
+  remove_table_other_con = function(ctx, con, table_name = "test") {
       con2 <- local_connection(ctx)
       dbWriteTable(con, "test", data.frame(a = 1L))
       expect_true("test" %in% dbListTables(con2))
@@ -107,10 +107,10 @@ spec_sql_remove_table <- list(
       dbRemoveTable(con, "test")
       expect_false("test" %in% dbListTables(con2))
       expect_false(dbExistsTable(con2, "test"))
-  }), # with_remove_test_table
+  },
 
   #' This function can also be used to remove a temporary table.
-  remove_table_temporary = function(ctx, con) with_remove_test_table(name = "test", {
+  remove_table_temporary = function(ctx, con, table_name = "test") {
       if (!isTRUE(ctx$tweaks$temporary_tables)) {
         skip("tweak: temporary_tables")
       }
@@ -126,7 +126,7 @@ spec_sql_remove_table <- list(
         expect_false("test" %in% dbListTables(con))
       }
       expect_false(dbExistsTable(con, "test"))
-  }), # with_remove_test_table
+  },
 
   #'
   #' The `name` argument is processed as follows,

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -11,37 +11,31 @@ spec_sql_write_table <- list(
 
   #' @return
   #' `dbWriteTable()` returns `TRUE`, invisibly.
-  write_table_return = function(con) {
-    with_remove_test_table({
+  write_table_return = function(con) with_remove_test_table({
       expect_invisible_true(dbWriteTable(con, "test", data.frame(a = 1L)))
-    })
-  },
+  }), # with_remove_test_table
 
   #' If the table exists, and both `append` and `overwrite` arguments are unset,
-  write_table_overwrite = function(con) {
-    with_remove_test_table({
+  write_table_overwrite = function(con) with_remove_test_table({
       test_in <- data.frame(a = 1L)
       dbWriteTable(con, "test", test_in)
       expect_error(dbWriteTable(con, "test", data.frame(a = 2L)))
 
       test_out <- check_df(dbReadTable(con, "test"))
       expect_equal_df(test_out, test_in)
-    })
-  },
+  }), # with_remove_test_table
 
   #' or `append = TRUE` and the data frame with the new data has different
   #' column names,
   #' an error is raised; the remote table remains unchanged.
-  write_table_append_incompatible = function(con) {
-    with_remove_test_table({
+  write_table_append_incompatible = function(con) with_remove_test_table({
       test_in <- data.frame(a = 1L)
       dbWriteTable(con, "test", test_in)
       expect_error(dbWriteTable(con, "test", data.frame(b = 2L), append = TRUE))
 
       test_out <- check_df(dbReadTable(con, "test"))
       expect_equal_df(test_out, test_in)
-    })
-  },
+  }), # with_remove_test_table
 
   #'
   #' An error is raised when calling this method for a closed
@@ -55,8 +49,7 @@ spec_sql_write_table <- list(
   },
 
   #' An error is also raised
-  write_table_error = function(ctx, con) {
-    with_remove_test_table({
+  write_table_error = function(ctx, con) with_remove_test_table({
       test_in <- data.frame(a = 1L)
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbWriteTable(con, NA, test_in))
@@ -94,9 +87,9 @@ spec_sql_write_table <- list(
       #' incompatible columns)
       dbWriteTable(con, "test", test_in)
       expect_error(dbWriteTable(con, "test", data.frame(b = 2L, c = 3L), append = TRUE))
-    })
-    #' also raise an error.
-  },
+
+      #' also raise an error.
+  }), # with_remove_test_table
 
   #' @section Additional arguments:
   #' The following arguments are not part of the `dbWriteTable()` generic
@@ -143,8 +136,7 @@ spec_sql_write_table <- list(
   #'
   #' If the `overwrite` argument is `TRUE`, an existing table of the same name
   #' will be overwritten.
-  overwrite_table = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  overwrite_table = function(ctx, con) with_remove_test_table(name = "iris", {
       iris <- get_iris(ctx)
       dbWriteTable(con, "iris", iris)
       expect_error(
@@ -153,12 +145,10 @@ spec_sql_write_table <- list(
       )
       iris_out <- check_df(dbReadTable(con, "iris"))
       expect_equal_df(iris_out, iris[1:10, ])
-    })
-  },
+  }), # with_remove_test_table
 
   #' This argument doesn't change behavior if the table does not exist yet.
-  overwrite_table_missing = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  overwrite_table_missing = function(ctx, con) with_remove_test_table(name = "iris", {
       iris_in <- get_iris(ctx)
       expect_error(
         dbWriteTable(con, "iris", iris[1:10, ], overwrite = TRUE),
@@ -166,37 +156,31 @@ spec_sql_write_table <- list(
       )
       iris_out <- check_df(dbReadTable(con, "iris"))
       expect_equal_df(iris_out, iris_in[1:10, ])
-    })
-  },
+  }), # with_remove_test_table
 
   #'
   #' If the `append` argument is `TRUE`, the rows in an existing table are
   #' preserved, and the new data are appended.
-  append_table = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  append_table = function(ctx, con) with_remove_test_table(name = "iris", {
       iris <- get_iris(ctx)
       dbWriteTable(con, "iris", iris)
       expect_error(dbWriteTable(con, "iris", iris[1:10, ], append = TRUE), NA)
       iris_out <- check_df(dbReadTable(con, "iris"))
       expect_equal_df(iris_out, rbind(iris, iris[1:10, ]))
-    })
-  },
+  }), # with_remove_test_table
 
   #' If the table doesn't exist yet, it is created.
-  append_table_new = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  append_table_new = function(ctx, con) with_remove_test_table(name = "iris", {
       iris <- get_iris(ctx)
       expect_error(dbWriteTable(con, "iris", iris[1:10, ], append = TRUE), NA)
       iris_out <- check_df(dbReadTable(con, "iris"))
       expect_equal_df(iris_out, iris[1:10, ])
-    })
-  },
+  }), # with_remove_test_table
 
   #'
   #' If the `temporary` argument is `TRUE`, the table is not available in a
   #' second connection and is gone after reconnecting.
-  temporary_table = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  temporary_table = function(ctx, con) with_remove_test_table(name = "iris", {
       #' Not all backends support this argument.
       if (!isTRUE(ctx$tweaks$temporary_tables)) {
         skip("tweak: temporary_tables")
@@ -209,8 +193,7 @@ spec_sql_write_table <- list(
 
       con2 <- local_connection(ctx)
       expect_error(dbReadTable(con2, "iris"))
-    })
-  },
+  }), # with_remove_test_table
   # second stage
   temporary_table = function(ctx, con) {
     if (!isTRUE(ctx$tweaks$temporary_tables)) {
@@ -232,14 +215,12 @@ spec_sql_write_table <- list(
     expect_equal_df(dbReadTable(con2, "iris"), iris30)
   },
   # second stage
-  table_visible_in_other_connection = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  table_visible_in_other_connection = function(ctx, con) with_remove_test_table(name = "iris", {
       #' and after reconnecting to the database.
       iris30 <- get_iris(ctx)[1:30, ]
 
       expect_equal_df(check_df(dbReadTable(con, "iris")), iris30)
-    })
-  },
+  }), # with_remove_test_table
 
   #'
   #' SQL keywords can be used freely in table names, column names, and data.
@@ -354,15 +335,13 @@ spec_sql_write_table <- list(
     )
   },
   #
-  roundtrip_64_bit_roundtrip = function(ctx, con) {
-    with_remove_test_table(name = table_name <- "test2", {
+  roundtrip_64_bit_roundtrip = function(ctx, con) with_remove_test_table(name = table_name <- "test2", {
       tbl_in <- data.frame(a = c(-1e14, 1e15))
       dbWriteTable(con, table_name, tbl_in, field.types = c(a = "BIGINT"))
       tbl_out <- dbReadTable(con, table_name)
       #'     - written to another table and read again unchanged
       test_table_roundtrip(con, tbl_out, tbl_expected = tbl_out)
-    })
-  },
+  }), # with_remove_test_table
 
   #' - character (in both UTF-8
   roundtrip_character = function(ctx, con) {
@@ -579,8 +558,7 @@ spec_sql_write_table <- list(
     }
   },
   #
-  write_table_row_names_true_exists = function(ctx, con) {
-    with_remove_test_table(name = "mtcars", {
+  write_table_row_names_true_exists = function(ctx, con) with_remove_test_table(name = "mtcars", {
       #' - If `TRUE`, row names are converted to a column named "row_names",
       row.names <- TRUE
 
@@ -592,11 +570,9 @@ spec_sql_write_table <- list(
       expect_true(all(rownames(mtcars_in) %in% mtcars_out$row_names))
       expect_true(all(mtcars_out$row_names %in% rownames(mtcars_in)))
       expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
-    })
-  },
+  }), # with_remove_test_table
   #
-  write_table_row_names_true_missing = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  write_table_row_names_true_missing = function(ctx, con) with_remove_test_table(name = "iris", {
       #'   even if the input data frame only has natural row names from 1 to `nrow(...)`.
       row.names <- TRUE
 
@@ -608,11 +584,9 @@ spec_sql_write_table <- list(
       expect_true(all(rownames(iris_in) %in% iris_out$row_names))
       expect_true(all(iris_out$row_names %in% rownames(iris_in)))
       expect_equal_df(iris_out[names(iris_out) != "row_names"], iris_in)
-    })
-  },
+  }), # with_remove_test_table
   #
-  write_table_row_names_na_exists = function(ctx, con) {
-    with_remove_test_table(name = "mtcars", {
+  write_table_row_names_na_exists = function(ctx, con) with_remove_test_table(name = "mtcars", {
       #' - If `NA`, a column named "row_names" is created if the data has custom row names,
       row.names <- NA
 
@@ -624,11 +598,9 @@ spec_sql_write_table <- list(
       expect_true(all(rownames(mtcars_in) %in% mtcars_out$row_names))
       expect_true(all(mtcars_out$row_names %in% rownames(mtcars_in)))
       expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
-    })
-  },
+  }), # with_remove_test_table
   #
-  write_table_row_names_na_missing = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  write_table_row_names_na_missing = function(ctx, con) with_remove_test_table(name = "iris", {
       #'   no extra column is created in the case of natural row names.
       row.names <- NA
 
@@ -637,11 +609,9 @@ spec_sql_write_table <- list(
       iris_out <- check_df(dbReadTable(con, "iris", row.names = FALSE))
 
       expect_equal_df(iris_out, iris_in)
-    })
-  },
+  }), # with_remove_test_table
   #
-  write_table_row_names_string_exists = function(ctx, con) {
-    with_remove_test_table(name = "mtcars", {
+  write_table_row_names_string_exists = function(ctx, con) with_remove_test_table(name = "mtcars", {
       row.names <- "make_model"
       #' - If a string, this specifies the name of the column in the remote table
       #'   that contains the row names,
@@ -655,11 +625,9 @@ spec_sql_write_table <- list(
       expect_true(all(mtcars_out$make_model %in% rownames(mtcars_in)))
       expect_true(all(rownames(mtcars_in) %in% mtcars_out$make_model))
       expect_equal_df(mtcars_out[names(mtcars_out) != "make_model"], unrowname(mtcars_in))
-    })
-  },
+  }), # with_remove_test_table
   #
-  write_table_row_names_string_missing = function(ctx, con) {
-    with_remove_test_table(name = "iris", {
+  write_table_row_names_string_missing = function(ctx, con) with_remove_test_table(name = "iris", {
       row.names <- "seq"
       #'   even if the input data frame only has natural row names.
 
@@ -671,11 +639,9 @@ spec_sql_write_table <- list(
       expect_true(all(iris_out$seq %in% rownames(iris_in)))
       expect_true(all(rownames(iris_in) %in% iris_out$seq))
       expect_equal_df(iris_out[names(iris_out) != "seq"], iris_in)
-    })
-  },
+  }), # with_remove_test_table
   #
-  write_table_row_names_default = function(ctx, con) {
-    with_remove_test_table(name = "mtcars", {
+  write_table_row_names_default = function(ctx, con) with_remove_test_table(name = "mtcars", {
       #'
       #' The default is `row.names = FALSE`.
       mtcars_in <- datasets::mtcars
@@ -684,8 +650,7 @@ spec_sql_write_table <- list(
 
       expect_false("row_names" %in% names(mtcars_out))
       expect_equal_df(mtcars_out, unrowname(mtcars_in))
-    })
-  },
+  }), # with_remove_test_table
   #
   NULL
 )

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -12,29 +12,29 @@ spec_sql_write_table <- list(
   #' @return
   #' `dbWriteTable()` returns `TRUE`, invisibly.
   write_table_return = function(con, table_name = "test") {
-      expect_invisible_true(dbWriteTable(con, "test", data.frame(a = 1L)))
+    expect_invisible_true(dbWriteTable(con, "test", data.frame(a = 1L)))
   },
 
   #' If the table exists, and both `append` and `overwrite` arguments are unset,
   write_table_overwrite = function(con, table_name = "test") {
-      test_in <- data.frame(a = 1L)
-      dbWriteTable(con, "test", test_in)
-      expect_error(dbWriteTable(con, "test", data.frame(a = 2L)))
+    test_in <- data.frame(a = 1L)
+    dbWriteTable(con, "test", test_in)
+    expect_error(dbWriteTable(con, "test", data.frame(a = 2L)))
 
-      test_out <- check_df(dbReadTable(con, "test"))
-      expect_equal_df(test_out, test_in)
+    test_out <- check_df(dbReadTable(con, "test"))
+    expect_equal_df(test_out, test_in)
   },
 
   #' or `append = TRUE` and the data frame with the new data has different
   #' column names,
   #' an error is raised; the remote table remains unchanged.
   write_table_append_incompatible = function(con, table_name = "test") {
-      test_in <- data.frame(a = 1L)
-      dbWriteTable(con, "test", test_in)
-      expect_error(dbWriteTable(con, "test", data.frame(b = 2L), append = TRUE))
+    test_in <- data.frame(a = 1L)
+    dbWriteTable(con, "test", test_in)
+    expect_error(dbWriteTable(con, "test", data.frame(b = 2L), append = TRUE))
 
-      test_out <- check_df(dbReadTable(con, "test"))
-      expect_equal_df(test_out, test_in)
+    test_out <- check_df(dbReadTable(con, "test"))
+    expect_equal_df(test_out, test_in)
   },
 
   #'
@@ -50,45 +50,45 @@ spec_sql_write_table <- list(
 
   #' An error is also raised
   write_table_error = function(ctx, con, table_name = "test") {
-      test_in <- data.frame(a = 1L)
-      #' if `name` cannot be processed with [dbQuoteIdentifier()]
-      expect_error(dbWriteTable(con, NA, test_in))
-      #' or if this results in a non-scalar.
-      expect_error(dbWriteTable(con, c("test", "test"), test_in))
+    test_in <- data.frame(a = 1L)
+    #' if `name` cannot be processed with [dbQuoteIdentifier()]
+    expect_error(dbWriteTable(con, NA, test_in))
+    #' or if this results in a non-scalar.
+    expect_error(dbWriteTable(con, c("test", "test"), test_in))
 
-      #' Invalid values for the additional arguments `row.names`,
-      #' `overwrite`, `append`, `field.types`, and `temporary`
-      #' (non-scalars,
-      expect_error(dbWriteTable(con, "test", test_in, row.names = letters))
-      expect_error(dbWriteTable(con, "test", test_in, overwrite = c(TRUE, FALSE)))
-      expect_error(dbWriteTable(con, "test", test_in, append = c(TRUE, FALSE)))
-      expect_error(dbWriteTable(con, "test", test_in, temporary = c(TRUE, FALSE)))
-      #' unsupported data types,
-      expect_error(dbWriteTable(con, "test", test_in, row.names = list(1L)))
-      expect_error(dbWriteTable(con, "test", test_in, overwrite = 1L))
-      expect_error(dbWriteTable(con, "test", test_in, append = 1L))
-      expect_error(dbWriteTable(con, "test", test_in, field.types = 1L))
-      expect_error(dbWriteTable(con, "test", test_in, temporary = 1L))
-      #' `NA`,
-      expect_error(dbWriteTable(con, "test", test_in, overwrite = NA))
-      expect_error(dbWriteTable(con, "test", test_in, append = NA))
-      expect_error(dbWriteTable(con, "test", test_in, field.types = NA))
-      expect_error(dbWriteTable(con, "test", test_in, temporary = NA))
-      #' incompatible values,
-      expect_error(dbWriteTable(con, "test", test_in, field.types = letters))
-      expect_error(dbWriteTable(con, "test", test_in, field.types = c(b = "INTEGER")))
-      expect_error(dbWriteTable(con, "test", test_in, overwrite = TRUE, append = TRUE))
-      expect_error(dbWriteTable(con, "test", test_in, append = TRUE, field.types = c(a = "INTEGER")))
-      #' duplicate
-      expect_error(dbWriteTable(con, "test", test_in, field.types = c(a = "INTEGER", a = "INTEGER")))
-      #' or missing names,
-      expect_error(dbWriteTable(con, "test", test_in, field.types = c("INTEGER")))
+    #' Invalid values for the additional arguments `row.names`,
+    #' `overwrite`, `append`, `field.types`, and `temporary`
+    #' (non-scalars,
+    expect_error(dbWriteTable(con, "test", test_in, row.names = letters))
+    expect_error(dbWriteTable(con, "test", test_in, overwrite = c(TRUE, FALSE)))
+    expect_error(dbWriteTable(con, "test", test_in, append = c(TRUE, FALSE)))
+    expect_error(dbWriteTable(con, "test", test_in, temporary = c(TRUE, FALSE)))
+    #' unsupported data types,
+    expect_error(dbWriteTable(con, "test", test_in, row.names = list(1L)))
+    expect_error(dbWriteTable(con, "test", test_in, overwrite = 1L))
+    expect_error(dbWriteTable(con, "test", test_in, append = 1L))
+    expect_error(dbWriteTable(con, "test", test_in, field.types = 1L))
+    expect_error(dbWriteTable(con, "test", test_in, temporary = 1L))
+    #' `NA`,
+    expect_error(dbWriteTable(con, "test", test_in, overwrite = NA))
+    expect_error(dbWriteTable(con, "test", test_in, append = NA))
+    expect_error(dbWriteTable(con, "test", test_in, field.types = NA))
+    expect_error(dbWriteTable(con, "test", test_in, temporary = NA))
+    #' incompatible values,
+    expect_error(dbWriteTable(con, "test", test_in, field.types = letters))
+    expect_error(dbWriteTable(con, "test", test_in, field.types = c(b = "INTEGER")))
+    expect_error(dbWriteTable(con, "test", test_in, overwrite = TRUE, append = TRUE))
+    expect_error(dbWriteTable(con, "test", test_in, append = TRUE, field.types = c(a = "INTEGER")))
+    #' duplicate
+    expect_error(dbWriteTable(con, "test", test_in, field.types = c(a = "INTEGER", a = "INTEGER")))
+    #' or missing names,
+    expect_error(dbWriteTable(con, "test", test_in, field.types = c("INTEGER")))
 
-      #' incompatible columns)
-      dbWriteTable(con, "test", test_in)
-      expect_error(dbWriteTable(con, "test", data.frame(b = 2L, c = 3L), append = TRUE))
+    #' incompatible columns)
+    dbWriteTable(con, "test", test_in)
+    expect_error(dbWriteTable(con, "test", data.frame(b = 2L, c = 3L), append = TRUE))
 
-      #' also raise an error.
+    #' also raise an error.
   },
 
   #' @section Additional arguments:
@@ -137,62 +137,62 @@ spec_sql_write_table <- list(
   #' If the `overwrite` argument is `TRUE`, an existing table of the same name
   #' will be overwritten.
   overwrite_table = function(ctx, con, table_name = "iris") {
-      iris <- get_iris(ctx)
-      dbWriteTable(con, "iris", iris)
-      expect_error(
-        dbWriteTable(con, "iris", iris[1:10, ], overwrite = TRUE),
-        NA
-      )
-      iris_out <- check_df(dbReadTable(con, "iris"))
-      expect_equal_df(iris_out, iris[1:10, ])
+    iris <- get_iris(ctx)
+    dbWriteTable(con, "iris", iris)
+    expect_error(
+      dbWriteTable(con, "iris", iris[1:10, ], overwrite = TRUE),
+      NA
+    )
+    iris_out <- check_df(dbReadTable(con, "iris"))
+    expect_equal_df(iris_out, iris[1:10, ])
   },
 
   #' This argument doesn't change behavior if the table does not exist yet.
   overwrite_table_missing = function(ctx, con, table_name = "iris") {
-      iris_in <- get_iris(ctx)
-      expect_error(
-        dbWriteTable(con, "iris", iris[1:10, ], overwrite = TRUE),
-        NA
-      )
-      iris_out <- check_df(dbReadTable(con, "iris"))
-      expect_equal_df(iris_out, iris_in[1:10, ])
+    iris_in <- get_iris(ctx)
+    expect_error(
+      dbWriteTable(con, "iris", iris[1:10, ], overwrite = TRUE),
+      NA
+    )
+    iris_out <- check_df(dbReadTable(con, "iris"))
+    expect_equal_df(iris_out, iris_in[1:10, ])
   },
 
   #'
   #' If the `append` argument is `TRUE`, the rows in an existing table are
   #' preserved, and the new data are appended.
   append_table = function(ctx, con, table_name = "iris") {
-      iris <- get_iris(ctx)
-      dbWriteTable(con, "iris", iris)
-      expect_error(dbWriteTable(con, "iris", iris[1:10, ], append = TRUE), NA)
-      iris_out <- check_df(dbReadTable(con, "iris"))
-      expect_equal_df(iris_out, rbind(iris, iris[1:10, ]))
+    iris <- get_iris(ctx)
+    dbWriteTable(con, "iris", iris)
+    expect_error(dbWriteTable(con, "iris", iris[1:10, ], append = TRUE), NA)
+    iris_out <- check_df(dbReadTable(con, "iris"))
+    expect_equal_df(iris_out, rbind(iris, iris[1:10, ]))
   },
 
   #' If the table doesn't exist yet, it is created.
   append_table_new = function(ctx, con, table_name = "iris") {
-      iris <- get_iris(ctx)
-      expect_error(dbWriteTable(con, "iris", iris[1:10, ], append = TRUE), NA)
-      iris_out <- check_df(dbReadTable(con, "iris"))
-      expect_equal_df(iris_out, iris[1:10, ])
+    iris <- get_iris(ctx)
+    expect_error(dbWriteTable(con, "iris", iris[1:10, ], append = TRUE), NA)
+    iris_out <- check_df(dbReadTable(con, "iris"))
+    expect_equal_df(iris_out, iris[1:10, ])
   },
 
   #'
   #' If the `temporary` argument is `TRUE`, the table is not available in a
   #' second connection and is gone after reconnecting.
   temporary_table = function(ctx, con, table_name = "iris") {
-      #' Not all backends support this argument.
-      if (!isTRUE(ctx$tweaks$temporary_tables)) {
-        skip("tweak: temporary_tables")
-      }
+    #' Not all backends support this argument.
+    if (!isTRUE(ctx$tweaks$temporary_tables)) {
+      skip("tweak: temporary_tables")
+    }
 
-      iris <- get_iris(ctx)[1:30, ]
-      dbWriteTable(con, "iris", iris, temporary = TRUE)
-      iris_out <- check_df(dbReadTable(con, "iris"))
-      expect_equal_df(iris_out, iris)
+    iris <- get_iris(ctx)[1:30, ]
+    dbWriteTable(con, "iris", iris, temporary = TRUE)
+    iris_out <- check_df(dbReadTable(con, "iris"))
+    expect_equal_df(iris_out, iris)
 
-      con2 <- local_connection(ctx)
-      expect_error(dbReadTable(con2, "iris"))
+    con2 <- local_connection(ctx)
+    expect_error(dbReadTable(con2, "iris"))
   },
   # second stage
   temporary_table = function(ctx, con) {
@@ -216,10 +216,10 @@ spec_sql_write_table <- list(
   },
   # second stage
   table_visible_in_other_connection = function(ctx, con, table_name = "iris") {
-      #' and after reconnecting to the database.
-      iris30 <- get_iris(ctx)[1:30, ]
+    #' and after reconnecting to the database.
+    iris30 <- get_iris(ctx)[1:30, ]
 
-      expect_equal_df(check_df(dbReadTable(con, "iris")), iris30)
+    expect_equal_df(check_df(dbReadTable(con, "iris")), iris30)
   },
 
   #'
@@ -336,11 +336,11 @@ spec_sql_write_table <- list(
   },
   #
   roundtrip_64_bit_roundtrip = function(con, table_name) {
-      tbl_in <- data.frame(a = c(-1e14, 1e15))
-      dbWriteTable(con, table_name, tbl_in, field.types = c(a = "BIGINT"))
-      tbl_out <- dbReadTable(con, table_name)
-      #'     - written to another table and read again unchanged
-      test_table_roundtrip(con, tbl_out, tbl_expected = tbl_out)
+    tbl_in <- data.frame(a = c(-1e14, 1e15))
+    dbWriteTable(con, table_name, tbl_in, field.types = c(a = "BIGINT"))
+    tbl_out <- dbReadTable(con, table_name)
+    #'     - written to another table and read again unchanged
+    test_table_roundtrip(con, tbl_out, tbl_expected = tbl_out)
   },
 
   #' - character (in both UTF-8
@@ -559,97 +559,97 @@ spec_sql_write_table <- list(
   },
   #
   write_table_row_names_true_exists = function(ctx, con, table_name = "mtcars") {
-      #' - If `TRUE`, row names are converted to a column named "row_names",
-      row.names <- TRUE
+    #' - If `TRUE`, row names are converted to a column named "row_names",
+    row.names <- TRUE
 
-      mtcars_in <- datasets::mtcars
-      dbWriteTable(con, "mtcars", mtcars_in, row.names = row.names)
-      mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
+    mtcars_in <- datasets::mtcars
+    dbWriteTable(con, "mtcars", mtcars_in, row.names = row.names)
+    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
 
-      expect_true("row_names" %in% names(mtcars_out))
-      expect_true(all(rownames(mtcars_in) %in% mtcars_out$row_names))
-      expect_true(all(mtcars_out$row_names %in% rownames(mtcars_in)))
-      expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
+    expect_true("row_names" %in% names(mtcars_out))
+    expect_true(all(rownames(mtcars_in) %in% mtcars_out$row_names))
+    expect_true(all(mtcars_out$row_names %in% rownames(mtcars_in)))
+    expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
   },
   #
   write_table_row_names_true_missing = function(ctx, con, table_name = "iris") {
-      #'   even if the input data frame only has natural row names from 1 to `nrow(...)`.
-      row.names <- TRUE
+    #'   even if the input data frame only has natural row names from 1 to `nrow(...)`.
+    row.names <- TRUE
 
-      iris_in <- get_iris(ctx)
-      dbWriteTable(con, "iris", iris_in, row.names = row.names)
-      iris_out <- check_df(dbReadTable(con, "iris", row.names = FALSE))
+    iris_in <- get_iris(ctx)
+    dbWriteTable(con, "iris", iris_in, row.names = row.names)
+    iris_out <- check_df(dbReadTable(con, "iris", row.names = FALSE))
 
-      expect_true("row_names" %in% names(iris_out))
-      expect_true(all(rownames(iris_in) %in% iris_out$row_names))
-      expect_true(all(iris_out$row_names %in% rownames(iris_in)))
-      expect_equal_df(iris_out[names(iris_out) != "row_names"], iris_in)
+    expect_true("row_names" %in% names(iris_out))
+    expect_true(all(rownames(iris_in) %in% iris_out$row_names))
+    expect_true(all(iris_out$row_names %in% rownames(iris_in)))
+    expect_equal_df(iris_out[names(iris_out) != "row_names"], iris_in)
   },
   #
   write_table_row_names_na_exists = function(ctx, con, table_name = "mtcars") {
-      #' - If `NA`, a column named "row_names" is created if the data has custom row names,
-      row.names <- NA
+    #' - If `NA`, a column named "row_names" is created if the data has custom row names,
+    row.names <- NA
 
-      mtcars_in <- datasets::mtcars
-      dbWriteTable(con, "mtcars", mtcars_in, row.names = row.names)
-      mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
+    mtcars_in <- datasets::mtcars
+    dbWriteTable(con, "mtcars", mtcars_in, row.names = row.names)
+    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
 
-      expect_true("row_names" %in% names(mtcars_out))
-      expect_true(all(rownames(mtcars_in) %in% mtcars_out$row_names))
-      expect_true(all(mtcars_out$row_names %in% rownames(mtcars_in)))
-      expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
+    expect_true("row_names" %in% names(mtcars_out))
+    expect_true(all(rownames(mtcars_in) %in% mtcars_out$row_names))
+    expect_true(all(mtcars_out$row_names %in% rownames(mtcars_in)))
+    expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
   },
   #
   write_table_row_names_na_missing = function(ctx, con, table_name = "iris") {
-      #'   no extra column is created in the case of natural row names.
-      row.names <- NA
+    #'   no extra column is created in the case of natural row names.
+    row.names <- NA
 
-      iris_in <- get_iris(ctx)
-      dbWriteTable(con, "iris", iris_in, row.names = row.names)
-      iris_out <- check_df(dbReadTable(con, "iris", row.names = FALSE))
+    iris_in <- get_iris(ctx)
+    dbWriteTable(con, "iris", iris_in, row.names = row.names)
+    iris_out <- check_df(dbReadTable(con, "iris", row.names = FALSE))
 
-      expect_equal_df(iris_out, iris_in)
+    expect_equal_df(iris_out, iris_in)
   },
   #
   write_table_row_names_string_exists = function(ctx, con, table_name = "mtcars") {
-      row.names <- "make_model"
-      #' - If a string, this specifies the name of the column in the remote table
-      #'   that contains the row names,
+    row.names <- "make_model"
+    #' - If a string, this specifies the name of the column in the remote table
+    #'   that contains the row names,
 
-      mtcars_in <- datasets::mtcars
+    mtcars_in <- datasets::mtcars
 
-      dbWriteTable(con, "mtcars", mtcars_in, row.names = row.names)
-      mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
+    dbWriteTable(con, "mtcars", mtcars_in, row.names = row.names)
+    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
 
-      expect_true("make_model" %in% names(mtcars_out))
-      expect_true(all(mtcars_out$make_model %in% rownames(mtcars_in)))
-      expect_true(all(rownames(mtcars_in) %in% mtcars_out$make_model))
-      expect_equal_df(mtcars_out[names(mtcars_out) != "make_model"], unrowname(mtcars_in))
+    expect_true("make_model" %in% names(mtcars_out))
+    expect_true(all(mtcars_out$make_model %in% rownames(mtcars_in)))
+    expect_true(all(rownames(mtcars_in) %in% mtcars_out$make_model))
+    expect_equal_df(mtcars_out[names(mtcars_out) != "make_model"], unrowname(mtcars_in))
   },
   #
   write_table_row_names_string_missing = function(ctx, con, table_name = "iris") {
-      row.names <- "seq"
-      #'   even if the input data frame only has natural row names.
+    row.names <- "seq"
+    #'   even if the input data frame only has natural row names.
 
-      iris_in <- get_iris(ctx)
-      dbWriteTable(con, "iris", iris_in, row.names = row.names)
-      iris_out <- check_df(dbReadTable(con, "iris", row.names = FALSE))
+    iris_in <- get_iris(ctx)
+    dbWriteTable(con, "iris", iris_in, row.names = row.names)
+    iris_out <- check_df(dbReadTable(con, "iris", row.names = FALSE))
 
-      expect_true("seq" %in% names(iris_out))
-      expect_true(all(iris_out$seq %in% rownames(iris_in)))
-      expect_true(all(rownames(iris_in) %in% iris_out$seq))
-      expect_equal_df(iris_out[names(iris_out) != "seq"], iris_in)
+    expect_true("seq" %in% names(iris_out))
+    expect_true(all(iris_out$seq %in% rownames(iris_in)))
+    expect_true(all(rownames(iris_in) %in% iris_out$seq))
+    expect_equal_df(iris_out[names(iris_out) != "seq"], iris_in)
   },
   #
   write_table_row_names_default = function(ctx, con, table_name = "mtcars") {
-      #'
-      #' The default is `row.names = FALSE`.
-      mtcars_in <- datasets::mtcars
-      dbWriteTable(con, "mtcars", mtcars_in)
-      mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
+    #'
+    #' The default is `row.names = FALSE`.
+    mtcars_in <- datasets::mtcars
+    dbWriteTable(con, "mtcars", mtcars_in)
+    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
 
-      expect_false("row_names" %in% names(mtcars_out))
-      expect_equal_df(mtcars_out, unrowname(mtcars_in))
+    expect_false("row_names" %in% names(mtcars_out))
+    expect_equal_df(mtcars_out, unrowname(mtcars_in))
   },
   #
   NULL

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -12,16 +12,16 @@ spec_sql_write_table <- list(
   #' @return
   #' `dbWriteTable()` returns `TRUE`, invisibly.
   write_table_return = function(con, table_name = "test") {
-    expect_invisible_true(dbWriteTable(con, "test", data.frame(a = 1L)))
+    expect_invisible_true(dbWriteTable(con, table_name, data.frame(a = 1L)))
   },
 
   #' If the table exists, and both `append` and `overwrite` arguments are unset,
   write_table_overwrite = function(con, table_name = "test") {
     test_in <- data.frame(a = 1L)
-    dbWriteTable(con, "test", test_in)
-    expect_error(dbWriteTable(con, "test", data.frame(a = 2L)))
+    dbWriteTable(con, table_name, test_in)
+    expect_error(dbWriteTable(con, table_name, data.frame(a = 2L)))
 
-    test_out <- check_df(dbReadTable(con, "test"))
+    test_out <- check_df(dbReadTable(con, table_name))
     expect_equal_df(test_out, test_in)
   },
 
@@ -30,10 +30,10 @@ spec_sql_write_table <- list(
   #' an error is raised; the remote table remains unchanged.
   write_table_append_incompatible = function(con, table_name = "test") {
     test_in <- data.frame(a = 1L)
-    dbWriteTable(con, "test", test_in)
-    expect_error(dbWriteTable(con, "test", data.frame(b = 2L), append = TRUE))
+    dbWriteTable(con, table_name, test_in)
+    expect_error(dbWriteTable(con, table_name, data.frame(b = 2L), append = TRUE))
 
-    test_out <- check_df(dbReadTable(con, "test"))
+    test_out <- check_df(dbReadTable(con, table_name))
     expect_equal_df(test_out, test_in)
   },
 
@@ -54,39 +54,39 @@ spec_sql_write_table <- list(
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbWriteTable(con, NA, test_in))
     #' or if this results in a non-scalar.
-    expect_error(dbWriteTable(con, c("test", "test"), test_in))
+    expect_error(dbWriteTable(con, c(table_name, table_name), test_in))
 
     #' Invalid values for the additional arguments `row.names`,
     #' `overwrite`, `append`, `field.types`, and `temporary`
     #' (non-scalars,
-    expect_error(dbWriteTable(con, "test", test_in, row.names = letters))
-    expect_error(dbWriteTable(con, "test", test_in, overwrite = c(TRUE, FALSE)))
-    expect_error(dbWriteTable(con, "test", test_in, append = c(TRUE, FALSE)))
-    expect_error(dbWriteTable(con, "test", test_in, temporary = c(TRUE, FALSE)))
+    expect_error(dbWriteTable(con, table_name, test_in, row.names = letters))
+    expect_error(dbWriteTable(con, table_name, test_in, overwrite = c(TRUE, FALSE)))
+    expect_error(dbWriteTable(con, table_name, test_in, append = c(TRUE, FALSE)))
+    expect_error(dbWriteTable(con, table_name, test_in, temporary = c(TRUE, FALSE)))
     #' unsupported data types,
-    expect_error(dbWriteTable(con, "test", test_in, row.names = list(1L)))
-    expect_error(dbWriteTable(con, "test", test_in, overwrite = 1L))
-    expect_error(dbWriteTable(con, "test", test_in, append = 1L))
-    expect_error(dbWriteTable(con, "test", test_in, field.types = 1L))
-    expect_error(dbWriteTable(con, "test", test_in, temporary = 1L))
+    expect_error(dbWriteTable(con, table_name, test_in, row.names = list(1L)))
+    expect_error(dbWriteTable(con, table_name, test_in, overwrite = 1L))
+    expect_error(dbWriteTable(con, table_name, test_in, append = 1L))
+    expect_error(dbWriteTable(con, table_name, test_in, field.types = 1L))
+    expect_error(dbWriteTable(con, table_name, test_in, temporary = 1L))
     #' `NA`,
-    expect_error(dbWriteTable(con, "test", test_in, overwrite = NA))
-    expect_error(dbWriteTable(con, "test", test_in, append = NA))
-    expect_error(dbWriteTable(con, "test", test_in, field.types = NA))
-    expect_error(dbWriteTable(con, "test", test_in, temporary = NA))
+    expect_error(dbWriteTable(con, table_name, test_in, overwrite = NA))
+    expect_error(dbWriteTable(con, table_name, test_in, append = NA))
+    expect_error(dbWriteTable(con, table_name, test_in, field.types = NA))
+    expect_error(dbWriteTable(con, table_name, test_in, temporary = NA))
     #' incompatible values,
-    expect_error(dbWriteTable(con, "test", test_in, field.types = letters))
-    expect_error(dbWriteTable(con, "test", test_in, field.types = c(b = "INTEGER")))
-    expect_error(dbWriteTable(con, "test", test_in, overwrite = TRUE, append = TRUE))
-    expect_error(dbWriteTable(con, "test", test_in, append = TRUE, field.types = c(a = "INTEGER")))
+    expect_error(dbWriteTable(con, table_name, test_in, field.types = letters))
+    expect_error(dbWriteTable(con, table_name, test_in, field.types = c(b = "INTEGER")))
+    expect_error(dbWriteTable(con, table_name, test_in, overwrite = TRUE, append = TRUE))
+    expect_error(dbWriteTable(con, table_name, test_in, append = TRUE, field.types = c(a = "INTEGER")))
     #' duplicate
-    expect_error(dbWriteTable(con, "test", test_in, field.types = c(a = "INTEGER", a = "INTEGER")))
+    expect_error(dbWriteTable(con, table_name, test_in, field.types = c(a = "INTEGER", a = "INTEGER")))
     #' or missing names,
-    expect_error(dbWriteTable(con, "test", test_in, field.types = c("INTEGER")))
+    expect_error(dbWriteTable(con, table_name, test_in, field.types = c("INTEGER")))
 
     #' incompatible columns)
-    dbWriteTable(con, "test", test_in)
-    expect_error(dbWriteTable(con, "test", data.frame(b = 2L, c = 3L), append = TRUE))
+    dbWriteTable(con, table_name, test_in)
+    expect_error(dbWriteTable(con, table_name, data.frame(b = 2L, c = 3L), append = TRUE))
 
     #' also raise an error.
   },

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -11,31 +11,31 @@ spec_sql_write_table <- list(
 
   #' @return
   #' `dbWriteTable()` returns `TRUE`, invisibly.
-  write_table_return = function(con) with_remove_test_table(name = "test", {
+  write_table_return = function(con, table_name = "test") {
       expect_invisible_true(dbWriteTable(con, "test", data.frame(a = 1L)))
-  }), # with_remove_test_table
+  },
 
   #' If the table exists, and both `append` and `overwrite` arguments are unset,
-  write_table_overwrite = function(con) with_remove_test_table(name = "test", {
+  write_table_overwrite = function(con, table_name = "test") {
       test_in <- data.frame(a = 1L)
       dbWriteTable(con, "test", test_in)
       expect_error(dbWriteTable(con, "test", data.frame(a = 2L)))
 
       test_out <- check_df(dbReadTable(con, "test"))
       expect_equal_df(test_out, test_in)
-  }), # with_remove_test_table
+  },
 
   #' or `append = TRUE` and the data frame with the new data has different
   #' column names,
   #' an error is raised; the remote table remains unchanged.
-  write_table_append_incompatible = function(con) with_remove_test_table(name = "test", {
+  write_table_append_incompatible = function(con, table_name = "test") {
       test_in <- data.frame(a = 1L)
       dbWriteTable(con, "test", test_in)
       expect_error(dbWriteTable(con, "test", data.frame(b = 2L), append = TRUE))
 
       test_out <- check_df(dbReadTable(con, "test"))
       expect_equal_df(test_out, test_in)
-  }), # with_remove_test_table
+  },
 
   #'
   #' An error is raised when calling this method for a closed
@@ -49,7 +49,7 @@ spec_sql_write_table <- list(
   },
 
   #' An error is also raised
-  write_table_error = function(ctx, con) with_remove_test_table(name = "test", {
+  write_table_error = function(ctx, con, table_name = "test") {
       test_in <- data.frame(a = 1L)
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbWriteTable(con, NA, test_in))
@@ -89,7 +89,7 @@ spec_sql_write_table <- list(
       expect_error(dbWriteTable(con, "test", data.frame(b = 2L, c = 3L), append = TRUE))
 
       #' also raise an error.
-  }), # with_remove_test_table
+  },
 
   #' @section Additional arguments:
   #' The following arguments are not part of the `dbWriteTable()` generic
@@ -136,7 +136,7 @@ spec_sql_write_table <- list(
   #'
   #' If the `overwrite` argument is `TRUE`, an existing table of the same name
   #' will be overwritten.
-  overwrite_table = function(ctx, con) with_remove_test_table(name = "iris", {
+  overwrite_table = function(ctx, con, table_name = "iris") {
       iris <- get_iris(ctx)
       dbWriteTable(con, "iris", iris)
       expect_error(
@@ -145,10 +145,10 @@ spec_sql_write_table <- list(
       )
       iris_out <- check_df(dbReadTable(con, "iris"))
       expect_equal_df(iris_out, iris[1:10, ])
-  }), # with_remove_test_table
+  },
 
   #' This argument doesn't change behavior if the table does not exist yet.
-  overwrite_table_missing = function(ctx, con) with_remove_test_table(name = "iris", {
+  overwrite_table_missing = function(ctx, con, table_name = "iris") {
       iris_in <- get_iris(ctx)
       expect_error(
         dbWriteTable(con, "iris", iris[1:10, ], overwrite = TRUE),
@@ -156,31 +156,31 @@ spec_sql_write_table <- list(
       )
       iris_out <- check_df(dbReadTable(con, "iris"))
       expect_equal_df(iris_out, iris_in[1:10, ])
-  }), # with_remove_test_table
+  },
 
   #'
   #' If the `append` argument is `TRUE`, the rows in an existing table are
   #' preserved, and the new data are appended.
-  append_table = function(ctx, con) with_remove_test_table(name = "iris", {
+  append_table = function(ctx, con, table_name = "iris") {
       iris <- get_iris(ctx)
       dbWriteTable(con, "iris", iris)
       expect_error(dbWriteTable(con, "iris", iris[1:10, ], append = TRUE), NA)
       iris_out <- check_df(dbReadTable(con, "iris"))
       expect_equal_df(iris_out, rbind(iris, iris[1:10, ]))
-  }), # with_remove_test_table
+  },
 
   #' If the table doesn't exist yet, it is created.
-  append_table_new = function(ctx, con) with_remove_test_table(name = "iris", {
+  append_table_new = function(ctx, con, table_name = "iris") {
       iris <- get_iris(ctx)
       expect_error(dbWriteTable(con, "iris", iris[1:10, ], append = TRUE), NA)
       iris_out <- check_df(dbReadTable(con, "iris"))
       expect_equal_df(iris_out, iris[1:10, ])
-  }), # with_remove_test_table
+  },
 
   #'
   #' If the `temporary` argument is `TRUE`, the table is not available in a
   #' second connection and is gone after reconnecting.
-  temporary_table = function(ctx, con) with_remove_test_table(name = "iris", {
+  temporary_table = function(ctx, con, table_name = "iris") {
       #' Not all backends support this argument.
       if (!isTRUE(ctx$tweaks$temporary_tables)) {
         skip("tweak: temporary_tables")
@@ -193,7 +193,7 @@ spec_sql_write_table <- list(
 
       con2 <- local_connection(ctx)
       expect_error(dbReadTable(con2, "iris"))
-  }), # with_remove_test_table
+  },
   # second stage
   temporary_table = function(ctx, con) {
     if (!isTRUE(ctx$tweaks$temporary_tables)) {
@@ -215,12 +215,12 @@ spec_sql_write_table <- list(
     expect_equal_df(dbReadTable(con2, "iris"), iris30)
   },
   # second stage
-  table_visible_in_other_connection = function(ctx, con) with_remove_test_table(name = "iris", {
+  table_visible_in_other_connection = function(ctx, con, table_name = "iris") {
       #' and after reconnecting to the database.
       iris30 <- get_iris(ctx)[1:30, ]
 
       expect_equal_df(check_df(dbReadTable(con, "iris")), iris30)
-  }), # with_remove_test_table
+  },
 
   #'
   #' SQL keywords can be used freely in table names, column names, and data.
@@ -558,7 +558,7 @@ spec_sql_write_table <- list(
     }
   },
   #
-  write_table_row_names_true_exists = function(ctx, con) with_remove_test_table(name = "mtcars", {
+  write_table_row_names_true_exists = function(ctx, con, table_name = "mtcars") {
       #' - If `TRUE`, row names are converted to a column named "row_names",
       row.names <- TRUE
 
@@ -570,9 +570,9 @@ spec_sql_write_table <- list(
       expect_true(all(rownames(mtcars_in) %in% mtcars_out$row_names))
       expect_true(all(mtcars_out$row_names %in% rownames(mtcars_in)))
       expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
-  }), # with_remove_test_table
+  },
   #
-  write_table_row_names_true_missing = function(ctx, con) with_remove_test_table(name = "iris", {
+  write_table_row_names_true_missing = function(ctx, con, table_name = "iris") {
       #'   even if the input data frame only has natural row names from 1 to `nrow(...)`.
       row.names <- TRUE
 
@@ -584,9 +584,9 @@ spec_sql_write_table <- list(
       expect_true(all(rownames(iris_in) %in% iris_out$row_names))
       expect_true(all(iris_out$row_names %in% rownames(iris_in)))
       expect_equal_df(iris_out[names(iris_out) != "row_names"], iris_in)
-  }), # with_remove_test_table
+  },
   #
-  write_table_row_names_na_exists = function(ctx, con) with_remove_test_table(name = "mtcars", {
+  write_table_row_names_na_exists = function(ctx, con, table_name = "mtcars") {
       #' - If `NA`, a column named "row_names" is created if the data has custom row names,
       row.names <- NA
 
@@ -598,9 +598,9 @@ spec_sql_write_table <- list(
       expect_true(all(rownames(mtcars_in) %in% mtcars_out$row_names))
       expect_true(all(mtcars_out$row_names %in% rownames(mtcars_in)))
       expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
-  }), # with_remove_test_table
+  },
   #
-  write_table_row_names_na_missing = function(ctx, con) with_remove_test_table(name = "iris", {
+  write_table_row_names_na_missing = function(ctx, con, table_name = "iris") {
       #'   no extra column is created in the case of natural row names.
       row.names <- NA
 
@@ -609,9 +609,9 @@ spec_sql_write_table <- list(
       iris_out <- check_df(dbReadTable(con, "iris", row.names = FALSE))
 
       expect_equal_df(iris_out, iris_in)
-  }), # with_remove_test_table
+  },
   #
-  write_table_row_names_string_exists = function(ctx, con) with_remove_test_table(name = "mtcars", {
+  write_table_row_names_string_exists = function(ctx, con, table_name = "mtcars") {
       row.names <- "make_model"
       #' - If a string, this specifies the name of the column in the remote table
       #'   that contains the row names,
@@ -625,9 +625,9 @@ spec_sql_write_table <- list(
       expect_true(all(mtcars_out$make_model %in% rownames(mtcars_in)))
       expect_true(all(rownames(mtcars_in) %in% mtcars_out$make_model))
       expect_equal_df(mtcars_out[names(mtcars_out) != "make_model"], unrowname(mtcars_in))
-  }), # with_remove_test_table
+  },
   #
-  write_table_row_names_string_missing = function(ctx, con) with_remove_test_table(name = "iris", {
+  write_table_row_names_string_missing = function(ctx, con, table_name = "iris") {
       row.names <- "seq"
       #'   even if the input data frame only has natural row names.
 
@@ -639,9 +639,9 @@ spec_sql_write_table <- list(
       expect_true(all(iris_out$seq %in% rownames(iris_in)))
       expect_true(all(rownames(iris_in) %in% iris_out$seq))
       expect_equal_df(iris_out[names(iris_out) != "seq"], iris_in)
-  }), # with_remove_test_table
+  },
   #
-  write_table_row_names_default = function(ctx, con) with_remove_test_table(name = "mtcars", {
+  write_table_row_names_default = function(ctx, con, table_name = "mtcars") {
       #'
       #' The default is `row.names = FALSE`.
       mtcars_in <- datasets::mtcars
@@ -650,7 +650,7 @@ spec_sql_write_table <- list(
 
       expect_false("row_names" %in% names(mtcars_out))
       expect_equal_df(mtcars_out, unrowname(mtcars_in))
-  }), # with_remove_test_table
+  },
   #
   NULL
 )

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -11,12 +11,12 @@ spec_sql_write_table <- list(
 
   #' @return
   #' `dbWriteTable()` returns `TRUE`, invisibly.
-  write_table_return = function(con) with_remove_test_table({
+  write_table_return = function(con) with_remove_test_table(name = "test", {
       expect_invisible_true(dbWriteTable(con, "test", data.frame(a = 1L)))
   }), # with_remove_test_table
 
   #' If the table exists, and both `append` and `overwrite` arguments are unset,
-  write_table_overwrite = function(con) with_remove_test_table({
+  write_table_overwrite = function(con) with_remove_test_table(name = "test", {
       test_in <- data.frame(a = 1L)
       dbWriteTable(con, "test", test_in)
       expect_error(dbWriteTable(con, "test", data.frame(a = 2L)))
@@ -28,7 +28,7 @@ spec_sql_write_table <- list(
   #' or `append = TRUE` and the data frame with the new data has different
   #' column names,
   #' an error is raised; the remote table remains unchanged.
-  write_table_append_incompatible = function(con) with_remove_test_table({
+  write_table_append_incompatible = function(con) with_remove_test_table(name = "test", {
       test_in <- data.frame(a = 1L)
       dbWriteTable(con, "test", test_in)
       expect_error(dbWriteTable(con, "test", data.frame(b = 2L), append = TRUE))
@@ -49,7 +49,7 @@ spec_sql_write_table <- list(
   },
 
   #' An error is also raised
-  write_table_error = function(ctx, con) with_remove_test_table({
+  write_table_error = function(ctx, con) with_remove_test_table(name = "test", {
       test_in <- data.frame(a = 1L)
       #' if `name` cannot be processed with [dbQuoteIdentifier()]
       expect_error(dbWriteTable(con, NA, test_in))

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -335,13 +335,13 @@ spec_sql_write_table <- list(
     )
   },
   #
-  roundtrip_64_bit_roundtrip = function(ctx, con) with_remove_test_table(name = table_name <- "test2", {
+  roundtrip_64_bit_roundtrip = function(con, table_name) {
       tbl_in <- data.frame(a = c(-1e14, 1e15))
       dbWriteTable(con, table_name, tbl_in, field.types = c(a = "BIGINT"))
       tbl_out <- dbReadTable(con, table_name)
       #'     - written to another table and read again unchanged
       test_table_roundtrip(con, tbl_out, tbl_expected = tbl_out)
-  }), # with_remove_test_table
+  },
 
   #' - character (in both UTF-8
   roundtrip_character = function(ctx, con) {

--- a/R/spec-transaction-begin-commit-rollback.R
+++ b/R/spec-transaction-begin-commit-rollback.R
@@ -109,11 +109,11 @@ spec_transaction_begin_commit_rollback <- list(
     expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
   },
   # second stage
-  begin_write_commit = function(con) with_remove_test_table(name = "test", {
+  begin_write_commit = function(con, table_name = "test") {
       #' and also in a new connection.
       expect_true(dbExistsTable(con, "test"))
       expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
-  }), # with_remove_test_table
+  },
   #
   begin_rollback = function(con) {
     #'
@@ -125,7 +125,7 @@ spec_transaction_begin_commit_rollback <- list(
 
   #' All data written in such a transaction must be removed after the
   #' transaction is rolled back.
-  begin_write_rollback = function(con) with_remove_test_table(name = "test", {
+  begin_write_rollback = function(con, table_name = "test") {
       #' For example, a record that is missing when the transaction is started
       dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
@@ -137,7 +137,7 @@ spec_transaction_begin_commit_rollback <- list(
       #' must not exist anymore after the rollback.
       dbRollback(con)
       expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
-  }), # with_remove_test_table
+  },
   #
   begin_write_disconnect = function(con) {
     #'
@@ -149,12 +149,12 @@ spec_transaction_begin_commit_rollback <- list(
     dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
   },
   #
-  begin_write_disconnect = function(con) with_remove_test_table(name = "test", {
+  begin_write_disconnect = function(con, table_name = "test") {
       #' effectively rolls back the transaction.
       #' All data written in such a transaction must be removed after the
       #' transaction is rolled back.
       expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
-  }), # with_remove_test_table
+  },
 
   #'
   #' The behavior is not specified if other arguments are passed to these

--- a/R/spec-transaction-begin-commit-rollback.R
+++ b/R/spec-transaction-begin-commit-rollback.R
@@ -109,13 +109,11 @@ spec_transaction_begin_commit_rollback <- list(
     expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
   },
   # second stage
-  begin_write_commit = function(con) {
-    with_remove_test_table({
+  begin_write_commit = function(con) with_remove_test_table({
       #' and also in a new connection.
       expect_true(dbExistsTable(con, "test"))
       expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
-    })
-  },
+  }), # with_remove_test_table
   #
   begin_rollback = function(con) {
     #'
@@ -127,8 +125,7 @@ spec_transaction_begin_commit_rollback <- list(
 
   #' All data written in such a transaction must be removed after the
   #' transaction is rolled back.
-  begin_write_rollback = function(con) {
-    with_remove_test_table({
+  begin_write_rollback = function(con) with_remove_test_table({
       #' For example, a record that is missing when the transaction is started
       dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
@@ -140,8 +137,7 @@ spec_transaction_begin_commit_rollback <- list(
       #' must not exist anymore after the rollback.
       dbRollback(con)
       expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
-    })
-  },
+  }), # with_remove_test_table
   #
   begin_write_disconnect = function(con) {
     #'
@@ -153,14 +149,12 @@ spec_transaction_begin_commit_rollback <- list(
     dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
   },
   #
-  begin_write_disconnect = function(con) {
-    with_remove_test_table({
+  begin_write_disconnect = function(con) with_remove_test_table({
       #' effectively rolls back the transaction.
       #' All data written in such a transaction must be removed after the
       #' transaction is rolled back.
       expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
-    })
-  },
+  }), # with_remove_test_table
 
   #'
   #' The behavior is not specified if other arguments are passed to these

--- a/R/spec-transaction-begin-commit-rollback.R
+++ b/R/spec-transaction-begin-commit-rollback.R
@@ -109,7 +109,7 @@ spec_transaction_begin_commit_rollback <- list(
     expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
   },
   # second stage
-  begin_write_commit = function(con) with_remove_test_table({
+  begin_write_commit = function(con) with_remove_test_table(name = "test", {
       #' and also in a new connection.
       expect_true(dbExistsTable(con, "test"))
       expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
@@ -125,7 +125,7 @@ spec_transaction_begin_commit_rollback <- list(
 
   #' All data written in such a transaction must be removed after the
   #' transaction is rolled back.
-  begin_write_rollback = function(con) with_remove_test_table({
+  begin_write_rollback = function(con) with_remove_test_table(name = "test", {
       #' For example, a record that is missing when the transaction is started
       dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
@@ -149,7 +149,7 @@ spec_transaction_begin_commit_rollback <- list(
     dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
   },
   #
-  begin_write_disconnect = function(con) with_remove_test_table({
+  begin_write_disconnect = function(con) with_remove_test_table(name = "test", {
       #' effectively rolls back the transaction.
       #' All data written in such a transaction must be removed after the
       #' transaction is rolled back.

--- a/R/spec-transaction-begin-commit-rollback.R
+++ b/R/spec-transaction-begin-commit-rollback.R
@@ -91,7 +91,8 @@ spec_transaction_begin_commit_rollback <- list(
   begin_write_commit = function(con) {
     #' For example, a record that is missing when the transaction is started
 
-    dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
+    table_name <- "test"
+    dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
 
     dbBegin(con)
     with_rollback_on_error({
@@ -99,20 +100,20 @@ spec_transaction_begin_commit_rollback <- list(
       dbExecute(con, paste0("INSERT INTO test (a) VALUES (1)"))
 
       #' must exist
-      expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
+      expect_equal(check_df(dbReadTable(con, table_name)), data.frame(a = 0:1))
 
       #' both during
       dbCommit(con)
     })
 
     #' and after the transaction,
-    expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
+    expect_equal(check_df(dbReadTable(con, table_name)), data.frame(a = 0:1))
   },
   # second stage
   begin_write_commit = function(con, table_name = "test") {
     #' and also in a new connection.
-    expect_true(dbExistsTable(con, "test"))
-    expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
+    expect_true(dbExistsTable(con, table_name))
+    expect_equal(check_df(dbReadTable(con, table_name)), data.frame(a = 0:1))
   },
   #
   begin_rollback = function(con) {
@@ -127,33 +128,34 @@ spec_transaction_begin_commit_rollback <- list(
   #' transaction is rolled back.
   begin_write_rollback = function(con, table_name = "test") {
     #' For example, a record that is missing when the transaction is started
-    dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
+    dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
 
     dbBegin(con)
 
     #' but is created during the transaction
-    dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
+    dbWriteTable(con, table_name, data.frame(a = 1L), append = TRUE)
 
     #' must not exist anymore after the rollback.
     dbRollback(con)
-    expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
+    expect_equal(check_df(dbReadTable(con, table_name)), data.frame(a = 0L))
   },
   #
   begin_write_disconnect = function(con) {
+    table_name <- "test"
     #'
     #' Disconnection from a connection with an open transaction
-    dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
+    dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
 
     dbBegin(con)
 
-    dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
+    dbWriteTable(con, table_name, data.frame(a = 1L), append = TRUE)
   },
   #
   begin_write_disconnect = function(con, table_name = "test") {
     #' effectively rolls back the transaction.
     #' All data written in such a transaction must be removed after the
     #' transaction is rolled back.
-    expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
+    expect_equal(check_df(dbReadTable(con, table_name)), data.frame(a = 0L))
   },
 
   #'

--- a/R/spec-transaction-begin-commit-rollback.R
+++ b/R/spec-transaction-begin-commit-rollback.R
@@ -110,9 +110,9 @@ spec_transaction_begin_commit_rollback <- list(
   },
   # second stage
   begin_write_commit = function(con, table_name = "test") {
-      #' and also in a new connection.
-      expect_true(dbExistsTable(con, "test"))
-      expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
+    #' and also in a new connection.
+    expect_true(dbExistsTable(con, "test"))
+    expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
   },
   #
   begin_rollback = function(con) {
@@ -126,17 +126,17 @@ spec_transaction_begin_commit_rollback <- list(
   #' All data written in such a transaction must be removed after the
   #' transaction is rolled back.
   begin_write_rollback = function(con, table_name = "test") {
-      #' For example, a record that is missing when the transaction is started
-      dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
+    #' For example, a record that is missing when the transaction is started
+    dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
-      dbBegin(con)
+    dbBegin(con)
 
-      #' but is created during the transaction
-      dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
+    #' but is created during the transaction
+    dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
 
-      #' must not exist anymore after the rollback.
-      dbRollback(con)
-      expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
+    #' must not exist anymore after the rollback.
+    dbRollback(con)
+    expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
   },
   #
   begin_write_disconnect = function(con) {
@@ -150,10 +150,10 @@ spec_transaction_begin_commit_rollback <- list(
   },
   #
   begin_write_disconnect = function(con, table_name = "test") {
-      #' effectively rolls back the transaction.
-      #' All data written in such a transaction must be removed after the
-      #' transaction is rolled back.
-      expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
+    #' effectively rolls back the transaction.
+    #' All data written in such a transaction must be removed after the
+    #' transaction is rolled back.
+    expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
   },
 
   #'

--- a/R/spec-transaction-with-transaction.R
+++ b/R/spec-transaction-with-transaction.R
@@ -38,7 +38,7 @@ spec_transaction_with_transaction <- list(
   #' `dbWithTransaction()` initiates a transaction with `dbBegin()`, executes
   #' the code given in the `code` argument, and commits the transaction with
   #' [dbCommit()].
-  with_transaction_success = function(con) with_remove_test_table({
+  with_transaction_success = function(con) with_remove_test_table(name = "test", {
       dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
       dbWithTransaction(
@@ -54,7 +54,7 @@ spec_transaction_with_transaction <- list(
 
   #' If the code raises an error, the transaction is instead aborted with
   #' [dbRollback()], and the error is propagated.
-  with_transaction_failure = function(con) with_remove_test_table({
+  with_transaction_failure = function(con) with_remove_test_table(name = "test", {
       dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
       name <- random_table_name()
@@ -75,7 +75,7 @@ spec_transaction_with_transaction <- list(
 
   #' If the code calls `dbBreak()`, execution of the code stops and the
   #' transaction is silently aborted.
-  with_transaction_break = function(con) with_remove_test_table({
+  with_transaction_break = function(con) with_remove_test_table(name = "test", {
       dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
       expect_error(

--- a/R/spec-transaction-with-transaction.R
+++ b/R/spec-transaction-with-transaction.R
@@ -38,8 +38,7 @@ spec_transaction_with_transaction <- list(
   #' `dbWithTransaction()` initiates a transaction with `dbBegin()`, executes
   #' the code given in the `code` argument, and commits the transaction with
   #' [dbCommit()].
-  with_transaction_success = function(con) {
-    with_remove_test_table({
+  with_transaction_success = function(con) with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
       dbWithTransaction(
@@ -51,13 +50,11 @@ spec_transaction_with_transaction <- list(
       )
 
       expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
-    })
-  },
+  }), # with_remove_test_table
 
   #' If the code raises an error, the transaction is instead aborted with
   #' [dbRollback()], and the error is propagated.
-  with_transaction_failure = function(con) {
-    with_remove_test_table({
+  with_transaction_failure = function(con) with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
       name <- random_table_name()
@@ -74,13 +71,11 @@ spec_transaction_with_transaction <- list(
       )
 
       expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
-    })
-  },
+  }), # with_remove_test_table
 
   #' If the code calls `dbBreak()`, execution of the code stops and the
   #' transaction is silently aborted.
-  with_transaction_break = function(con) {
-    with_remove_test_table({
+  with_transaction_break = function(con) with_remove_test_table({
       dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
       expect_error(
@@ -95,8 +90,7 @@ spec_transaction_with_transaction <- list(
       )
 
       expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
-    })
-  },
+  }), # with_remove_test_table
 
   #' All side effects caused by the code
   with_transaction_side_effects = function(con) {

--- a/R/spec-transaction-with-transaction.R
+++ b/R/spec-transaction-with-transaction.R
@@ -39,57 +39,57 @@ spec_transaction_with_transaction <- list(
   #' the code given in the `code` argument, and commits the transaction with
   #' [dbCommit()].
   with_transaction_success = function(con, table_name = "test") {
-      dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
+    dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
-      dbWithTransaction(
-        con,
-        {
-          dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
-          expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
-        }
-      )
+    dbWithTransaction(
+      con,
+      {
+        dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
+        expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
+      }
+    )
 
-      expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
+    expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
   },
 
   #' If the code raises an error, the transaction is instead aborted with
   #' [dbRollback()], and the error is propagated.
   with_transaction_failure = function(con, table_name = "test") {
-      dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
+    dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
-      name <- random_table_name()
-      expect_error(
-        dbWithTransaction(
-          con,
-          {
-            dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
-            stop(name)
-          }
-        ),
-        name,
-        fixed = TRUE
-      )
+    name <- random_table_name()
+    expect_error(
+      dbWithTransaction(
+        con,
+        {
+          dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
+          stop(name)
+        }
+      ),
+      name,
+      fixed = TRUE
+    )
 
-      expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
+    expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
   },
 
   #' If the code calls `dbBreak()`, execution of the code stops and the
   #' transaction is silently aborted.
   with_transaction_break = function(con, table_name = "test") {
-      dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
+    dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
-      expect_error(
-        dbWithTransaction(
-          con,
-          {
-            dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
-            dbBreak()
-          }
-        ),
-        NA
-      )
+    expect_error(
+      dbWithTransaction(
+        con,
+        {
+          dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
+          dbBreak()
+        }
+      ),
+      NA
+    )
 
-      expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
+    expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
   },
 
   #' All side effects caused by the code

--- a/R/spec-transaction-with-transaction.R
+++ b/R/spec-transaction-with-transaction.R
@@ -38,7 +38,7 @@ spec_transaction_with_transaction <- list(
   #' `dbWithTransaction()` initiates a transaction with `dbBegin()`, executes
   #' the code given in the `code` argument, and commits the transaction with
   #' [dbCommit()].
-  with_transaction_success = function(con) with_remove_test_table(name = "test", {
+  with_transaction_success = function(con, table_name = "test") {
       dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
       dbWithTransaction(
@@ -50,11 +50,11 @@ spec_transaction_with_transaction <- list(
       )
 
       expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
-  }), # with_remove_test_table
+  },
 
   #' If the code raises an error, the transaction is instead aborted with
   #' [dbRollback()], and the error is propagated.
-  with_transaction_failure = function(con) with_remove_test_table(name = "test", {
+  with_transaction_failure = function(con, table_name = "test") {
       dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
       name <- random_table_name()
@@ -71,11 +71,11 @@ spec_transaction_with_transaction <- list(
       )
 
       expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
-  }), # with_remove_test_table
+  },
 
   #' If the code calls `dbBreak()`, execution of the code stops and the
   #' transaction is silently aborted.
-  with_transaction_break = function(con) with_remove_test_table(name = "test", {
+  with_transaction_break = function(con, table_name = "test") {
       dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
 
       expect_error(
@@ -90,7 +90,7 @@ spec_transaction_with_transaction <- list(
       )
 
       expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
-  }), # with_remove_test_table
+  },
 
   #' All side effects caused by the code
   with_transaction_side_effects = function(con) {

--- a/R/spec-transaction-with-transaction.R
+++ b/R/spec-transaction-with-transaction.R
@@ -39,30 +39,30 @@ spec_transaction_with_transaction <- list(
   #' the code given in the `code` argument, and commits the transaction with
   #' [dbCommit()].
   with_transaction_success = function(con, table_name = "test") {
-    dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
+    dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
 
     dbWithTransaction(
       con,
       {
-        dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
-        expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
+        dbWriteTable(con, table_name, data.frame(a = 1L), append = TRUE)
+        expect_equal(check_df(dbReadTable(con, table_name)), data.frame(a = 0:1))
       }
     )
 
-    expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0:1))
+    expect_equal(check_df(dbReadTable(con, table_name)), data.frame(a = 0:1))
   },
 
   #' If the code raises an error, the transaction is instead aborted with
   #' [dbRollback()], and the error is propagated.
   with_transaction_failure = function(con, table_name = "test") {
-    dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
+    dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
 
     name <- random_table_name()
     expect_error(
       dbWithTransaction(
         con,
         {
-          dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
+          dbWriteTable(con, table_name, data.frame(a = 1L), append = TRUE)
           stop(name)
         }
       ),
@@ -70,26 +70,26 @@ spec_transaction_with_transaction <- list(
       fixed = TRUE
     )
 
-    expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
+    expect_equal(check_df(dbReadTable(con, table_name)), data.frame(a = 0L))
   },
 
   #' If the code calls `dbBreak()`, execution of the code stops and the
   #' transaction is silently aborted.
   with_transaction_break = function(con, table_name = "test") {
-    dbWriteTable(con, "test", data.frame(a = 0L), overwrite = TRUE)
+    dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
 
     expect_error(
       dbWithTransaction(
         con,
         {
-          dbWriteTable(con, "test", data.frame(a = 1L), append = TRUE)
+          dbWriteTable(con, table_name, data.frame(a = 1L), append = TRUE)
           dbBreak()
         }
       ),
       NA
     )
 
-    expect_equal(check_df(dbReadTable(con, "test")), data.frame(a = 0L))
+    expect_equal(check_df(dbReadTable(con, table_name)), data.frame(a = 0L))
   },
 
   #' All side effects caused by the code

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,6 +28,29 @@ local_invalid_connection <- function(ctx, ...) {
   unserialize(serialize(con, NULL))
 }
 
+local_remove_test_table <- function(con, name, ..., .local_envir = parent.frame()) {
+  withr::defer(try_silent(dbRemoveTable(con, name)), envir = .local_envir)
+}
+
+with_remove_test_table <- function(code, name = "test", con = "con", env = parent.frame()) {
+  code_sub <- substitute(code)
+
+  con <- as.name(con)
+
+  eval(
+    bquote({
+      on.exit(
+        try_silent(
+          dbRemoveTable(.(con), .(name))
+        ),
+        add = TRUE
+      )
+      local(.(code_sub))
+    }),
+    envir = env
+  )
+}
+
 # Evaluates the code inside local() after defining a variable "res"
 # (can be overridden by specifying con argument)
 # that points to a result set created by query. Clears on exit.

--- a/tests/testthat/test-consistency.R
+++ b/tests/testthat/test-consistency.R
@@ -18,8 +18,10 @@ test_that("no duplicate spec names expect known exceptions", {
   all_names <- all_names[!(all_names %in% c(
     "create_temporary_table",
     "create_table_visible_in_other_connection",
+    "list_tables",
     "exists_table",
     "temporary_table",
+    "list_objects",
     "table_visible_in_other_connection",
     "begin_write_disconnect",
     "begin_write_commit"

--- a/tests/testthat/test-consistency.R
+++ b/tests/testthat/test-consistency.R
@@ -18,6 +18,7 @@ test_that("no duplicate spec names expect known exceptions", {
   all_names <- all_names[!(all_names %in% c(
     "create_temporary_table",
     "create_table_visible_in_other_connection",
+    "exists_table",
     "temporary_table",
     "table_visible_in_other_connection",
     "begin_write_disconnect",


### PR DESCRIPTION
and avoid many instances of `with_remove_test_table()`.