### PR TITLE
Use random table names

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -128,7 +128,7 @@ patch_test_fun <- function(test_fun, desc) {
 }
 
 wrap_all_statements_with_expect_no_warning <- function(block) {
-  # stopifnot(identical(block[[1]], quote(`{`)))
+  stopifnot(identical(block[[1]], quote(`{`)))
   block[-1] <- lapply(block[-1], function(x) expr(expect_warning(!!x, NA)))
   block
 }

--- a/R/spec-meta-column-info.R
+++ b/R/spec-meta-column-info.R
@@ -10,7 +10,7 @@ spec_meta_column_info <- list(
 
   #' @return
   #' `dbColumnInfo()`
-  column_info = function(ctx, con, table_name = "iris") {
+  column_info = function(ctx, con, table_name) {
     iris <- get_iris(ctx)
     dbWriteTable(con, table_name, iris)
 

--- a/R/spec-meta-column-info.R
+++ b/R/spec-meta-column-info.R
@@ -52,7 +52,7 @@ spec_meta_column_info <- list(
   #' @section Specification:
   #'
   #' A column named `row_names` is treated like any other column.
-  column_info_row_names = function(con, table_name = "test2") {
+  column_info_row_names = function(con, table_name) {
     dbWriteTable(con, table_name, data.frame(a = 1L, row_names = 2L))
     with_result(
       dbSendQuery(con, paste0("SELECT * FROM ", table_name)),

--- a/R/spec-meta-column-info.R
+++ b/R/spec-meta-column-info.R
@@ -15,7 +15,7 @@ spec_meta_column_info <- list(
     dbWriteTable(con, table_name, iris)
 
     with_result(
-      dbSendQuery(con, "SELECT * FROM iris"),
+      dbSendQuery(con, paste0("SELECT * FROM ", table_name)),
       {
         fields <- dbColumnInfo(res)
         #' returns a data frame

--- a/R/spec-meta-column-info.R
+++ b/R/spec-meta-column-info.R
@@ -52,7 +52,7 @@ spec_meta_column_info <- list(
   #' @section Specification:
   #'
   #' A column named `row_names` is treated like any other column.
-  column_info_row_names = function(con, table_name = "test") {
+  column_info_row_names = function(con, table_name = "test2") {
     dbWriteTable(con, table_name, data.frame(a = 1L, row_names = 2L))
     with_result(
       dbSendQuery(con, paste0("SELECT * FROM ", table_name)),

--- a/R/spec-meta-column-info.R
+++ b/R/spec-meta-column-info.R
@@ -12,7 +12,7 @@ spec_meta_column_info <- list(
   #' `dbColumnInfo()`
   column_info = function(ctx, con, table_name = "iris") {
     iris <- get_iris(ctx)
-    dbWriteTable(con, "iris", iris)
+    dbWriteTable(con, table_name, iris)
 
     with_result(
       dbSendQuery(con, "SELECT * FROM iris"),

--- a/R/spec-meta-column-info.R
+++ b/R/spec-meta-column-info.R
@@ -55,7 +55,7 @@ spec_meta_column_info <- list(
   column_info_row_names = function(con, table_name = "test") {
     dbWriteTable(con, table_name, data.frame(a = 1L, row_names = 2L))
     with_result(
-      dbSendQuery(con, "SELECT * FROM test"),
+      dbSendQuery(con, paste0("SELECT * FROM ", table_name)),
       {
         expect_identical(dbColumnInfo(res)$name, c("a", "row_names"))
       }

--- a/R/spec-meta-get-rows-affected.R
+++ b/R/spec-meta-get-rows-affected.R
@@ -11,7 +11,7 @@ spec_meta_get_rows_affected <- list(
   #' @return
   #' `dbGetRowsAffected()` returns a scalar number (integer or numeric),
   #' the number of rows affected by a data manipulation statement
-  rows_affected_statement = function(con, table_name = "test") {
+  rows_affected_statement = function(con, table_name = "test2") {
     dbWriteTable(con, table_name, data.frame(a = 1:10))
 
     query <- paste0(
@@ -50,7 +50,7 @@ spec_meta_get_rows_affected <- list(
     )
   },
   #
-  get_rows_affected_error = function(con, table_name = "test") {
+  get_rows_affected_error = function(con, table_name = "test2") {
     query <- paste0(
       "CREATE TABLE ", dbQuoteIdentifier(con, table_name), " (a integer)"
     )

--- a/R/spec-meta-get-rows-affected.R
+++ b/R/spec-meta-get-rows-affected.R
@@ -11,7 +11,7 @@ spec_meta_get_rows_affected <- list(
   #' @return
   #' `dbGetRowsAffected()` returns a scalar number (integer or numeric),
   #' the number of rows affected by a data manipulation statement
-  rows_affected_statement = function(con, table_name = "test2") {
+  rows_affected_statement = function(con, table_name) {
     dbWriteTable(con, table_name, data.frame(a = 1:10))
 
     query <- paste0(
@@ -50,7 +50,7 @@ spec_meta_get_rows_affected <- list(
     )
   },
   #
-  get_rows_affected_error = function(con, table_name = "test2") {
+  get_rows_affected_error = function(con, table_name) {
     query <- paste0(
       "CREATE TABLE ", dbQuoteIdentifier(con, table_name), " (a integer)"
     )

--- a/R/spec-meta-is-valid.R
+++ b/R/spec-meta-is-valid.R
@@ -40,7 +40,7 @@ spec_meta_is_valid <- list(
     expect_false(dbIsValid(res))
   },
   #
-  is_valid_result_statement = function(con, table_name = "test") {
+  is_valid_result_statement = function(con, table_name = "test2") {
     query <- paste0("CREATE TABLE ", table_name, " (a ", dbDataType(con, 1L), ")")
     res <- dbSendStatement(con, query)
     #' A [DBIResult-class] object is also valid after a call to [dbSendStatement()],

--- a/R/spec-meta-is-valid.R
+++ b/R/spec-meta-is-valid.R
@@ -41,7 +41,7 @@ spec_meta_is_valid <- list(
   },
   #
   is_valid_result_statement = function(con, table_name = "test") {
-    query <- paste0("CREATE TABLE test (a ", dbDataType(con, 1L), ")")
+    query <- paste0("CREATE TABLE ", table_name, " (a ", dbDataType(con, 1L), ")")
     res <- dbSendStatement(con, query)
     #' A [DBIResult-class] object is also valid after a call to [dbSendStatement()],
     expect_true(expect_visible(dbIsValid(res)))

--- a/R/spec-meta-is-valid.R
+++ b/R/spec-meta-is-valid.R
@@ -40,7 +40,7 @@ spec_meta_is_valid <- list(
     expect_false(dbIsValid(res))
   },
   #
-  is_valid_result_statement = function(con, table_name = "test2") {
+  is_valid_result_statement = function(con, table_name) {
     query <- paste0("CREATE TABLE ", table_name, " (a ", dbDataType(con, 1L), ")")
     res <- dbSendStatement(con, query)
     #' A [DBIResult-class] object is also valid after a call to [dbSendStatement()],

--- a/R/spec-result-create-table-with-data-type.R
+++ b/R/spec-result-create-table-with-data-type.R
@@ -8,9 +8,10 @@ spec_result_create_table_with_data_type <- list(
   #' of the form
   data_type_create_table = function(ctx, con) {
     check_connection_data_type <- function(value) {
-      with_remove_test_table(name = "test", {
+      table_name <- "test"
+      with_remove_test_table(name = table_name, {
         #' `"CREATE TABLE test (a ...)"`.
-        query <- paste0("CREATE TABLE test (a ", dbDataType(con, value), ")")
+        query <- paste0("CREATE TABLE ", table_name, " (a ", dbDataType(con, value), ")")
         eval(bquote(dbExecute(con, .(query))))
       })
     }

--- a/R/spec-result-create-table-with-data-type.R
+++ b/R/spec-result-create-table-with-data-type.R
@@ -8,7 +8,7 @@ spec_result_create_table_with_data_type <- list(
   #' of the form
   data_type_create_table = function(ctx, con) {
     check_connection_data_type <- function(value) {
-      table_name <- "test"
+      table_name <- random_table_name()
       with_remove_test_table(name = table_name, {
         #' `"CREATE TABLE test (a ...)"`.
         query <- paste0("CREATE TABLE ", table_name, " (a ", dbDataType(con, value), ")")

--- a/R/spec-result-execute.R
+++ b/R/spec-result-execute.R
@@ -65,7 +65,7 @@ spec_result_execute <- list(
       with_remove_test_table(name = table_name, {
         dbWriteTable(con, table_name, data.frame(a = as.numeric(1:3)))
         placeholder <- placeholder_fun(1)
-        query <- paste0("DELETE FROM test WHERE a > ", placeholder)
+        query <- paste0("DELETE FROM ", table_name, " WHERE a > ", placeholder)
         values <- 1.5
         params <- stats::setNames(list(values), names(placeholder))
         ret <- dbExecute(con, query, params = params)

--- a/R/spec-result-execute.R
+++ b/R/spec-result-execute.R
@@ -10,7 +10,7 @@ spec_result_execute <- list(
 
   #' @return
   #' `dbExecute()` always returns a
-  execute_atomic = function(con, table_name = "test2") {
+  execute_atomic = function(con, table_name) {
     query <- trivial_statement(table_name)
 
     ret <- dbExecute(con, query)
@@ -75,7 +75,7 @@ spec_result_execute <- list(
   },
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
-  execute_immediate = function(con, table_name = "test2") {
+  execute_immediate = function(con, table_name) {
     res <- expect_visible(dbExecute(con, trivial_statement(table_name), immediate = TRUE))
     expect_true(is.numeric(res))
   },

--- a/R/spec-result-execute.R
+++ b/R/spec-result-execute.R
@@ -11,7 +11,7 @@ spec_result_execute <- list(
   #' @return
   #' `dbExecute()` always returns a
   execute_atomic = function(con, table_name = "test") {
-    query <- trivial_statement()
+    query <- trivial_statement(table_name)
 
     ret <- dbExecute(con, query)
     #' scalar
@@ -24,12 +24,12 @@ spec_result_execute <- list(
 
   #' An error is raised when issuing a statement over a closed
   execute_closed_connection = function(ctx, closed_con) {
-    expect_error(dbExecute(closed_con, trivial_statement()))
+    expect_error(dbExecute(closed_con, trivial_statement(table_name = "test")))
   },
 
   #' or invalid connection,
   execute_invalid_connection = function(ctx, invalid_con) {
-    expect_error(dbExecute(invalid_con, trivial_statement()))
+    expect_error(dbExecute(invalid_con, trivial_statement(table_name = "test")))
   },
 
   #' if the syntax of the statement is invalid,
@@ -76,7 +76,7 @@ spec_result_execute <- list(
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
   execute_immediate = function(con, table_name = "test") {
-    res <- expect_visible(dbExecute(con, trivial_statement(), immediate = TRUE))
+    res <- expect_visible(dbExecute(con, trivial_statement(table_name), immediate = TRUE))
     expect_true(is.numeric(res))
   },
   #

--- a/R/spec-result-execute.R
+++ b/R/spec-result-execute.R
@@ -24,12 +24,14 @@ spec_result_execute <- list(
 
   #' An error is raised when issuing a statement over a closed
   execute_closed_connection = function(ctx, closed_con) {
-    expect_error(dbExecute(closed_con, trivial_statement(table_name = "test2")))
+    table_name <- "dbit12"
+    expect_error(dbExecute(closed_con, trivial_statement(table_name = table_name)))
   },
 
   #' or invalid connection,
   execute_invalid_connection = function(ctx, invalid_con) {
-    expect_error(dbExecute(invalid_con, trivial_statement(table_name = "test2")))
+    table_name <- "dbit13"
+    expect_error(dbExecute(invalid_con, trivial_statement(table_name = table_name)))
   },
 
   #' if the syntax of the statement is invalid,

--- a/R/spec-result-execute.R
+++ b/R/spec-result-execute.R
@@ -10,7 +10,7 @@ spec_result_execute <- list(
 
   #' @return
   #' `dbExecute()` always returns a
-  execute_atomic = function(con, table_name = "test") {
+  execute_atomic = function(con, table_name = "test2") {
     query <- trivial_statement(table_name)
 
     ret <- dbExecute(con, query)
@@ -24,12 +24,12 @@ spec_result_execute <- list(
 
   #' An error is raised when issuing a statement over a closed
   execute_closed_connection = function(ctx, closed_con) {
-    expect_error(dbExecute(closed_con, trivial_statement(table_name = "test")))
+    expect_error(dbExecute(closed_con, trivial_statement(table_name = "test2")))
   },
 
   #' or invalid connection,
   execute_invalid_connection = function(ctx, invalid_con) {
-    expect_error(dbExecute(invalid_con, trivial_statement(table_name = "test")))
+    expect_error(dbExecute(invalid_con, trivial_statement(table_name = "test2")))
   },
 
   #' if the syntax of the statement is invalid,
@@ -75,7 +75,7 @@ spec_result_execute <- list(
   },
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
-  execute_immediate = function(con, table_name = "test") {
+  execute_immediate = function(con, table_name = "test2") {
     res <- expect_visible(dbExecute(con, trivial_statement(table_name), immediate = TRUE))
     expect_true(is.numeric(res))
   },

--- a/R/spec-result-execute.R
+++ b/R/spec-result-execute.R
@@ -60,7 +60,7 @@ spec_result_execute <- list(
   execute_params = function(ctx, con) {
     placeholder_funs <- get_placeholder_funs(ctx)
 
-    table_name <- "test"
+    table_name <- random_table_name()
     for (placeholder_fun in placeholder_funs) {
       with_remove_test_table(name = table_name, {
         dbWriteTable(con, table_name, data.frame(a = as.numeric(1:3)))

--- a/R/spec-result-fetch.R
+++ b/R/spec-result-fetch.R
@@ -92,7 +92,7 @@ spec_result_fetch <- list(
   #' Calling `dbFetch()` on a result set from a data manipulation query
   #' created by [dbSendStatement()]
   #' can be fetched and return an empty data frame, with a warning.
-  fetch_no_return_value = function(con, table_name = "test") {
+  fetch_no_return_value = function(con, table_name = "test2") {
     query <- paste0("CREATE TABLE ", table_name, " (a integer)")
 
     with_result(

--- a/R/spec-result-fetch.R
+++ b/R/spec-result-fetch.R
@@ -93,7 +93,7 @@ spec_result_fetch <- list(
   #' created by [dbSendStatement()]
   #' can be fetched and return an empty data frame, with a warning.
   fetch_no_return_value = function(con, table_name = "test") {
-    query <- "CREATE TABLE test (a integer)"
+    query <- paste0("CREATE TABLE ", table_name, " (a integer)")
 
     with_result(
       dbSendStatement(con, query),

--- a/R/spec-result-fetch.R
+++ b/R/spec-result-fetch.R
@@ -92,7 +92,7 @@ spec_result_fetch <- list(
   #' Calling `dbFetch()` on a result set from a data manipulation query
   #' created by [dbSendStatement()]
   #' can be fetched and return an empty data frame, with a warning.
-  fetch_no_return_value = function(con, table_name = "test2") {
+  fetch_no_return_value = function(con, table_name) {
     query <- paste0("CREATE TABLE ", table_name, " (a integer)")
 
     with_result(

--- a/R/spec-result-get-query.R
+++ b/R/spec-result-get-query.R
@@ -208,7 +208,7 @@ spec_result_get_query <- list(
   #'     1. A query with parameters is passed:
   #'         1. `params` not given: waiting for parameters via [dbBind()]
   #'         1. `params` given: query is executed
-  get_query_immediate = function(con, table_name = "test") {
+  get_query_immediate = function(con, table_name = "test2") {
     res <- expect_visible(dbGetQuery(con, trivial_query(), immediate = TRUE))
     expect_s3_class(res, "data.frame")
   },

--- a/R/spec-result-get-query.R
+++ b/R/spec-result-get-query.R
@@ -208,7 +208,7 @@ spec_result_get_query <- list(
   #'     1. A query with parameters is passed:
   #'         1. `params` not given: waiting for parameters via [dbBind()]
   #'         1. `params` given: query is executed
-  get_query_immediate = function(con, table_name = "test2") {
+  get_query_immediate = function(con, table_name) {
     res <- expect_visible(dbGetQuery(con, trivial_query(), immediate = TRUE))
     expect_s3_class(res, "data.frame")
   },

--- a/R/spec-result-send-query.R
+++ b/R/spec-result-send-query.R
@@ -107,7 +107,7 @@ spec_result_send_query <- list(
   },
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
-  send_query_immediate = function(con, table_name = "test") {
+  send_query_immediate = function(con, table_name = "test2") {
     res <- expect_visible(dbSendQuery(con, trivial_query(), immediate = TRUE))
     expect_s4_class(res, "DBIResult")
     expect_error(dbGetRowsAffected(res), NA)

--- a/R/spec-result-send-query.R
+++ b/R/spec-result-send-query.R
@@ -71,8 +71,8 @@ spec_result_send_query <- list(
     on.exit(dbDisconnect(con))
     expect_warning(dbSendQuery(con, trivial_query()), NA)
 
-    on.exit(NULL)
     expect_warning({ dbDisconnect(con); gc() })
+    on.exit(NULL)
   },
 
   #'

--- a/R/spec-result-send-query.R
+++ b/R/spec-result-send-query.R
@@ -107,7 +107,7 @@ spec_result_send_query <- list(
   },
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
-  send_query_immediate = function(con, table_name = "test2") {
+  send_query_immediate = function(con, table_name) {
     res <- expect_visible(dbSendQuery(con, trivial_query(), immediate = TRUE))
     expect_s4_class(res, "DBIResult")
     expect_error(dbGetRowsAffected(res), NA)

--- a/R/spec-result-send-query.R
+++ b/R/spec-result-send-query.R
@@ -72,7 +72,7 @@ spec_result_send_query <- list(
     expect_warning(dbSendQuery(con, trivial_query()), NA)
 
     on.exit(NULL)
-    expect_warning(dbDisconnect(con))
+    expect_warning({ dbDisconnect(con); gc() })
   },
 
   #'

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -10,7 +10,7 @@ spec_result_send_statement <- list(
 
   #' @return
   #' `dbSendStatement()` returns
-  send_statement_trivial = function(con, table_name = "test") {
+  send_statement_trivial = function(con, table_name = "test2") {
     res <- expect_visible(dbSendStatement(con, trivial_statement(table_name)))
     #' an S4 object that inherits from [DBIResult-class].
     expect_s4_class(res, "DBIResult")
@@ -24,12 +24,12 @@ spec_result_send_statement <- list(
 
   #' An error is raised when issuing a statement over a closed
   send_statement_closed_connection = function(ctx, closed_con) {
-    expect_error(dbSendStatement(closed_con, trivial_statement(table_name = "test")))
+    expect_error(dbSendStatement(closed_con, trivial_statement(table_name = "test2")))
   },
 
   #' or invalid connection,
   send_statement_invalid_connection = function(ctx, invalid_con) {
-    expect_error(dbSendStatement(invalid_con, trivial_statement(table_name = "test")))
+    expect_error(dbSendStatement(invalid_con, trivial_statement(table_name = "test2")))
   },
 
   #' or if the statement is not a non-`NA` string.
@@ -48,7 +48,7 @@ spec_result_send_statement <- list(
   },
 
   #' @section Specification:
-  send_statement_result_valid = function(con, table_name = "test") {
+  send_statement_result_valid = function(con, table_name = "test2") {
     #' No warnings occur under normal conditions.
     expect_warning(res <- dbSendStatement(con, trivial_statement(table_name)), NA)
     #' When done, the DBIResult object must be cleared with a call to
@@ -68,7 +68,7 @@ spec_result_send_statement <- list(
   },
 
   #' If the backend supports only one open result set per connection,
-  send_statement_only_one_result_set = function(con, table_name = "test") {
+  send_statement_only_one_result_set = function(con, table_name = "test2") {
     res1 <- dbSendStatement(con, trivial_statement(table_name))
     other_table_name <- random_table_name()
     with_remove_test_table(name = other_table_name, {
@@ -116,7 +116,7 @@ spec_result_send_statement <- list(
   },
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
-  send_statement_immediate = function(con, table_name = "test") {
+  send_statement_immediate = function(con, table_name = "test2") {
     res <- expect_visible(dbSendStatement(con, trivial_statement(table_name), immediate = TRUE))
     expect_s4_class(res, "DBIResult")
     expect_error(dbGetRowsAffected(res), NA)

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -10,7 +10,7 @@ spec_result_send_statement <- list(
 
   #' @return
   #' `dbSendStatement()` returns
-  send_statement_trivial = function(con, table_name = "test2") {
+  send_statement_trivial = function(con, table_name) {
     res <- expect_visible(dbSendStatement(con, trivial_statement(table_name)))
     #' an S4 object that inherits from [DBIResult-class].
     expect_s4_class(res, "DBIResult")
@@ -48,7 +48,7 @@ spec_result_send_statement <- list(
   },
 
   #' @section Specification:
-  send_statement_result_valid = function(con, table_name = "test2") {
+  send_statement_result_valid = function(con, table_name) {
     #' No warnings occur under normal conditions.
     expect_warning(res <- dbSendStatement(con, trivial_statement(table_name)), NA)
     #' When done, the DBIResult object must be cleared with a call to
@@ -68,7 +68,7 @@ spec_result_send_statement <- list(
   },
 
   #' If the backend supports only one open result set per connection,
-  send_statement_only_one_result_set = function(con, table_name = "test2") {
+  send_statement_only_one_result_set = function(con, table_name) {
     res1 <- dbSendStatement(con, trivial_statement(table_name))
     other_table_name <- random_table_name()
     with_remove_test_table(name = other_table_name, {
@@ -116,7 +116,7 @@ spec_result_send_statement <- list(
   },
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
-  send_statement_immediate = function(con, table_name = "test2") {
+  send_statement_immediate = function(con, table_name) {
     res <- expect_visible(dbSendStatement(con, trivial_statement(table_name), immediate = TRUE))
     expect_s4_class(res, "DBIResult")
     expect_error(dbGetRowsAffected(res), NA)

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -103,7 +103,7 @@ spec_result_send_statement <- list(
       with_remove_test_table(name = table_name, {
         dbWriteTable(con, table_name, data.frame(a = as.numeric(1:3)))
         placeholder <- placeholder_fun(1)
-        query <- paste0("DELETE FROM test WHERE a > ", placeholder)
+        query <- paste0("DELETE FROM ", table_name, " WHERE a > ", placeholder)
         values <- 1.5
         params <- stats::setNames(list(values), names(placeholder))
         rs <- dbSendStatement(con, query, params = params)

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -65,8 +65,8 @@ spec_result_send_statement <- list(
     on.exit(dbDisconnect(con))
     expect_warning(dbSendStatement(con, trivial_query()), NA)
 
-    on.exit(NULL)
     expect_warning({ dbDisconnect(con); gc() })
+    on.exit(NULL)
   },
 
   #' If the backend supports only one open result set per connection,

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -66,7 +66,7 @@ spec_result_send_statement <- list(
     expect_warning(dbSendStatement(con, trivial_query()), NA)
 
     on.exit(NULL)
-    expect_warning(dbDisconnect(con))
+    expect_warning({ dbDisconnect(con); gc() })
   },
 
   #' If the backend supports only one open result set per connection,

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -100,7 +100,7 @@ spec_result_send_statement <- list(
   send_statement_params = function(ctx, con) {
     placeholder_funs <- get_placeholder_funs(ctx)
 
-    table_name <- "test"
+    table_name <- random_table_name()
     for (placeholder_fun in placeholder_funs) {
       with_remove_test_table(name = table_name, {
         dbWriteTable(con, table_name, data.frame(a = as.numeric(1:3)))

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -11,7 +11,7 @@ spec_result_send_statement <- list(
   #' @return
   #' `dbSendStatement()` returns
   send_statement_trivial = function(con, table_name = "test") {
-    res <- expect_visible(dbSendStatement(con, trivial_statement()))
+    res <- expect_visible(dbSendStatement(con, trivial_statement(table_name)))
     #' an S4 object that inherits from [DBIResult-class].
     expect_s4_class(res, "DBIResult")
     #' The result set can be used with [dbGetRowsAffected()] to
@@ -24,12 +24,12 @@ spec_result_send_statement <- list(
 
   #' An error is raised when issuing a statement over a closed
   send_statement_closed_connection = function(ctx, closed_con) {
-    expect_error(dbSendStatement(closed_con, trivial_statement()))
+    expect_error(dbSendStatement(closed_con, trivial_statement(table_name = "test")))
   },
 
   #' or invalid connection,
   send_statement_invalid_connection = function(ctx, invalid_con) {
-    expect_error(dbSendStatement(invalid_con, trivial_statement()))
+    expect_error(dbSendStatement(invalid_con, trivial_statement(table_name = "test")))
   },
 
   #' or if the statement is not a non-`NA` string.
@@ -50,7 +50,7 @@ spec_result_send_statement <- list(
   #' @section Specification:
   send_statement_result_valid = function(con, table_name = "test") {
     #' No warnings occur under normal conditions.
-    expect_warning(res <- dbSendStatement(con, trivial_statement()), NA)
+    expect_warning(res <- dbSendStatement(con, trivial_statement(table_name)), NA)
     #' When done, the DBIResult object must be cleared with a call to
     #' [dbClearResult()].
     dbClearResult(res)
@@ -69,7 +69,7 @@ spec_result_send_statement <- list(
 
   #' If the backend supports only one open result set per connection,
   send_statement_only_one_result_set = function(con, table_name = "test") {
-    res1 <- dbSendStatement(con, trivial_statement())
+    res1 <- dbSendStatement(con, trivial_statement(table_name))
     with_remove_test_table(name = "test2", {
       #' issuing a second query invalidates an already open result set
       #' and raises a warning.
@@ -115,7 +115,7 @@ spec_result_send_statement <- list(
 
   #' @inheritSection spec_result_get_query Specification for the `immediate` argument
   send_statement_immediate = function(con, table_name = "test") {
-    res <- expect_visible(dbSendStatement(con, trivial_statement(), immediate = TRUE))
+    res <- expect_visible(dbSendStatement(con, trivial_statement(table_name), immediate = TRUE))
     expect_s4_class(res, "DBIResult")
     expect_error(dbGetRowsAffected(res), NA)
     dbClearResult(res)

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -70,10 +70,12 @@ spec_result_send_statement <- list(
   #' If the backend supports only one open result set per connection,
   send_statement_only_one_result_set = function(con, table_name = "test") {
     res1 <- dbSendStatement(con, trivial_statement(table_name))
-    with_remove_test_table(name = "test2", {
+    other_table_name <- random_table_name()
+    with_remove_test_table(name = other_table_name, {
       #' issuing a second query invalidates an already open result set
       #' and raises a warning.
-      expect_warning(res2 <- dbSendStatement(con, "CREATE TABLE test2 AS SELECT 1 AS a"))
+      query <- paste0("CREATE TABLE ", other_table_name, " AS SELECT 1 AS a")
+      expect_warning(res2 <- dbSendStatement(con, query))
       expect_false(dbIsValid(res1))
       #' The newly opened result set is valid
       expect_true(dbIsValid(res2))

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -24,12 +24,14 @@ spec_result_send_statement <- list(
 
   #' An error is raised when issuing a statement over a closed
   send_statement_closed_connection = function(ctx, closed_con) {
-    expect_error(dbSendStatement(closed_con, trivial_statement(table_name = "test2")))
+    table_name <- "dbit10"
+    expect_error(dbSendStatement(closed_con, trivial_statement(table_name = table_name)))
   },
 
   #' or invalid connection,
   send_statement_invalid_connection = function(ctx, invalid_con) {
-    expect_error(dbSendStatement(invalid_con, trivial_statement(table_name = "test2")))
+    table_name <- "dbit11"
+    expect_error(dbSendStatement(invalid_con, trivial_statement(table_name = table_name)))
   },
 
   #' or if the statement is not a non-`NA` string.

--- a/R/spec-result.R
+++ b/R/spec-result.R
@@ -22,7 +22,7 @@ union <- function(..., .order_by = NULL, .ctx) {
   query
 }
 
-trivial_statement <- function(table_name = "test") {
+trivial_statement <- function(table_name = "test2") {
   paste0("CREATE TABLE ", table_name, " AS ", trivial_query())
 }
 

--- a/R/spec-result.R
+++ b/R/spec-result.R
@@ -22,7 +22,7 @@ union <- function(..., .order_by = NULL, .ctx) {
   query
 }
 
-trivial_statement <- function(table_name = "test2") {
+trivial_statement <- function(table_name) {
   paste0("CREATE TABLE ", table_name, " AS ", trivial_query())
 }
 

--- a/R/spec-sql-append-table.R
+++ b/R/spec-sql-append-table.R
@@ -414,7 +414,7 @@ spec_sql_append_table <- list(
   #'
   #'
   #' The `row.names` argument must be `NULL`, the default value.
-  append_table_row_names_false = function(con, table_name = "mtcars") {
+  append_table_row_names_false = function(con, table_name) {
     mtcars_in <- datasets::mtcars
     dbCreateTable(con, table_name, mtcars_in)
     dbAppendTable(con, table_name, mtcars_in)
@@ -425,7 +425,7 @@ spec_sql_append_table <- list(
   },
 
   #' Row names are ignored.
-  append_table_row_names_ignore = function(con, table_name = "mtcars") {
+  append_table_row_names_ignore = function(con, table_name) {
     mtcars_in <- datasets::mtcars
     dbCreateTable(con, table_name, mtcars_in)
     dbAppendTable(con, table_name, mtcars_in, row.names = NULL)
@@ -435,7 +435,7 @@ spec_sql_append_table <- list(
     expect_equal_df(mtcars_out, unrowname(mtcars_in))
   },
   #
-  append_table_row_names_non_null = function(con, table_name = "mtcars") {
+  append_table_row_names_non_null = function(con, table_name) {
     #' All other values for the `row.names` argument
     mtcars_in <- datasets::mtcars
     dbCreateTable(con, table_name, mtcars_in)

--- a/R/spec-sql-append-table.R
+++ b/R/spec-sql-append-table.R
@@ -10,7 +10,7 @@ spec_sql_append_table <- list(
 
   #' @return
   #' `dbAppendTable()` returns a
-  append_table_return = function(con, table_name = "test2") {
+  append_table_return = function(con, table_name) {
     test_in <- trivial_df()
     dbCreateTable(con, table_name, test_in)
     ret <- dbAppendTable(con, table_name, test_in)
@@ -22,7 +22,7 @@ spec_sql_append_table <- list(
   },
 
   #' If the table does not exist,
-  append_table_missing = function(con, table_name = "test2") {
+  append_table_missing = function(con, table_name) {
     expect_false(dbExistsTable(con, table_name))
 
     test_in <- trivial_df()
@@ -31,7 +31,7 @@ spec_sql_append_table <- list(
 
   #' or the data frame with the new data has different column names,
   #' an error is raised; the remote table remains unchanged.
-  append_table_append_incompatible = function(con, table_name = "test2") {
+  append_table_append_incompatible = function(con, table_name) {
     test_in <- trivial_df()
     dbCreateTable(con, table_name, test_in)
     dbAppendTable(con, table_name, test_in)
@@ -53,7 +53,7 @@ spec_sql_append_table <- list(
   },
 
   #' An error is also raised
-  append_table_error = function(con, table_name = "test2") {
+  append_table_error = function(con, table_name) {
     test_in <- data.frame(a = 1L)
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbAppendTable(con, NA, test_in))

--- a/R/spec-sql-append-table.R
+++ b/R/spec-sql-append-table.R
@@ -10,7 +10,7 @@ spec_sql_append_table <- list(
 
   #' @return
   #' `dbAppendTable()` returns a
-  append_table_return = function(con, table_name = "test") {
+  append_table_return = function(con, table_name = "test2") {
     test_in <- trivial_df()
     dbCreateTable(con, table_name, test_in)
     ret <- dbAppendTable(con, table_name, test_in)
@@ -22,7 +22,7 @@ spec_sql_append_table <- list(
   },
 
   #' If the table does not exist,
-  append_table_missing = function(con, table_name = "test") {
+  append_table_missing = function(con, table_name = "test2") {
     expect_false(dbExistsTable(con, table_name))
 
     test_in <- trivial_df()
@@ -31,7 +31,7 @@ spec_sql_append_table <- list(
 
   #' or the data frame with the new data has different column names,
   #' an error is raised; the remote table remains unchanged.
-  append_table_append_incompatible = function(con, table_name = "test") {
+  append_table_append_incompatible = function(con, table_name = "test2") {
     test_in <- trivial_df()
     dbCreateTable(con, table_name, test_in)
     dbAppendTable(con, table_name, test_in)
@@ -53,7 +53,7 @@ spec_sql_append_table <- list(
   },
 
   #' An error is also raised
-  append_table_error = function(con, table_name = "test") {
+  append_table_error = function(con, table_name = "test2") {
     test_in <- data.frame(a = 1L)
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbAppendTable(con, NA, test_in))

--- a/R/spec-sql-append-table.R
+++ b/R/spec-sql-append-table.R
@@ -416,9 +416,9 @@ spec_sql_append_table <- list(
   #' The `row.names` argument must be `NULL`, the default value.
   append_table_row_names_false = function(con, table_name = "mtcars") {
     mtcars_in <- datasets::mtcars
-    dbCreateTable(con, "mtcars", mtcars_in)
-    dbAppendTable(con, "mtcars", mtcars_in)
-    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
+    dbCreateTable(con, table_name, mtcars_in)
+    dbAppendTable(con, table_name, mtcars_in)
+    mtcars_out <- check_df(dbReadTable(con, table_name, row.names = FALSE))
 
     expect_false("row_names" %in% names(mtcars_out))
     expect_equal_df(mtcars_out, unrowname(mtcars_in))
@@ -427,9 +427,9 @@ spec_sql_append_table <- list(
   #' Row names are ignored.
   append_table_row_names_ignore = function(con, table_name = "mtcars") {
     mtcars_in <- datasets::mtcars
-    dbCreateTable(con, "mtcars", mtcars_in)
-    dbAppendTable(con, "mtcars", mtcars_in, row.names = NULL)
-    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
+    dbCreateTable(con, table_name, mtcars_in)
+    dbAppendTable(con, table_name, mtcars_in, row.names = NULL)
+    mtcars_out <- check_df(dbReadTable(con, table_name, row.names = FALSE))
 
     expect_false("row_names" %in% names(mtcars_out))
     expect_equal_df(mtcars_out, unrowname(mtcars_in))
@@ -438,14 +438,14 @@ spec_sql_append_table <- list(
   append_table_row_names_non_null = function(con, table_name = "mtcars") {
     #' All other values for the `row.names` argument
     mtcars_in <- datasets::mtcars
-    dbCreateTable(con, "mtcars", mtcars_in)
+    dbCreateTable(con, table_name, mtcars_in)
 
     #' (in particular `TRUE`,
-    expect_error(dbAppendTable(con, "mtcars", mtcars_in, row.names = TRUE))
+    expect_error(dbAppendTable(con, table_name, mtcars_in, row.names = TRUE))
     #' `NA`,
-    expect_error(dbAppendTable(con, "mtcars", mtcars_in, row.names = NA))
+    expect_error(dbAppendTable(con, table_name, mtcars_in, row.names = NA))
     #' and a string)
-    expect_error(dbAppendTable(con, "mtcars", mtcars_in, row.names = "make_model"))
+    expect_error(dbAppendTable(con, table_name, mtcars_in, row.names = "make_model"))
 
     #' raise an error.
   },

--- a/R/spec-sql-create-table.R
+++ b/R/spec-sql-create-table.R
@@ -107,7 +107,7 @@ spec_sql_create_table <- list(
   #'
   #' If the `temporary` argument is `TRUE`, the table is not available in a
   #' second connection and is gone after reconnecting.
-  create_temporary_table = function(ctx, con, table_name = "dbit3") {
+  create_temporary_table = function(ctx, con, table_name = "dbit03") {
     #' Not all backends support this argument.
     if (!isTRUE(ctx$tweaks$temporary_tables)) {
       skip("tweak: temporary_tables")
@@ -123,7 +123,7 @@ spec_sql_create_table <- list(
   },
   # second stage
   create_temporary_table = function(con) {
-    table_name <- "dbit3"
+    table_name <- "dbit03"
     expect_error(dbReadTable(con, table_name))
   },
 
@@ -131,7 +131,7 @@ spec_sql_create_table <- list(
   create_table_visible_in_other_connection = function(ctx, con) {
     iris <- get_iris(ctx)[1:30, ]
 
-    table_name <- "dbit4"
+    table_name <- "dbit04"
     dbCreateTable(con, table_name, iris)
     iris_out <- check_df(dbReadTable(con, table_name))
     expect_equal_df(iris_out, iris[0, , drop = FALSE])
@@ -140,7 +140,7 @@ spec_sql_create_table <- list(
     expect_equal_df(dbReadTable(con2, table_name), iris[0, , drop = FALSE])
   },
   # second stage
-  create_table_visible_in_other_connection = function(con, table_name = "dbit4") {
+  create_table_visible_in_other_connection = function(con, table_name = "dbit04") {
     #' and after reconnecting to the database.
     expect_equal_df(check_df(dbReadTable(con, table_name)), iris[0, , drop = FALSE])
   },

--- a/R/spec-sql-create-table.R
+++ b/R/spec-sql-create-table.R
@@ -10,12 +10,12 @@ spec_sql_create_table <- list(
 
   #' @return
   #' `dbCreateTable()` returns `TRUE`, invisibly.
-  create_table_return = function(con, table_name = "test2") {
+  create_table_return = function(con, table_name) {
     expect_invisible_true(dbCreateTable(con, table_name, trivial_df()))
   },
 
   #' If the table exists, an error is raised; the remote table remains unchanged.
-  create_table_overwrite = function(con, table_name = "test2") {
+  create_table_overwrite = function(con, table_name) {
     test_in <- trivial_df()
 
     dbCreateTable(con, table_name, test_in)
@@ -38,7 +38,7 @@ spec_sql_create_table <- list(
   },
 
   #' An error is also raised
-  create_table_error = function(ctx, con, table_name = "test2") {
+  create_table_error = function(ctx, con, table_name) {
     test_in <- data.frame(a = 1L)
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbCreateTable(con, NA, test_in))

--- a/R/spec-sql-create-table.R
+++ b/R/spec-sql-create-table.R
@@ -185,7 +185,7 @@ spec_sql_create_table <- list(
 
   #'
   #' The `row.names` argument must be missing
-  create_table_row_names_default = function(ctx, con, table_name = "mtcars") {
+  create_table_row_names_default = function(ctx, con, table_name) {
     mtcars_in <- datasets::mtcars
     dbCreateTable(con, table_name, mtcars_in)
     mtcars_out <- check_df(dbReadTable(con, table_name, row.names = FALSE))
@@ -194,7 +194,7 @@ spec_sql_create_table <- list(
     expect_equal_df(mtcars_out, unrowname(mtcars_in)[0, , drop = FALSE])
   },
   #' or `NULL`, the default value.
-  create_table_row_names_null = function(ctx, con, table_name = "mtcars") {
+  create_table_row_names_null = function(ctx, con, table_name) {
     mtcars_in <- datasets::mtcars
     dbCreateTable(con, table_name, mtcars_in, row.names = NULL)
     mtcars_out <- check_df(dbReadTable(con, table_name, row.names = NULL))
@@ -203,7 +203,7 @@ spec_sql_create_table <- list(
     expect_equal_df(mtcars_out, unrowname(mtcars_in)[0, , drop = FALSE])
   },
   #
-  create_table_row_names_non_null = function(ctx, con, table_name = "mtcars") {
+  create_table_row_names_non_null = function(ctx, con, table_name) {
     #' All other values for the `row.names` argument
     mtcars_in <- datasets::mtcars
 

--- a/R/spec-sql-create-table.R
+++ b/R/spec-sql-create-table.R
@@ -187,8 +187,8 @@ spec_sql_create_table <- list(
   #' The `row.names` argument must be missing
   create_table_row_names_default = function(ctx, con, table_name = "mtcars") {
     mtcars_in <- datasets::mtcars
-    dbCreateTable(con, "mtcars", mtcars_in)
-    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
+    dbCreateTable(con, table_name, mtcars_in)
+    mtcars_out <- check_df(dbReadTable(con, table_name, row.names = FALSE))
 
     expect_false("row_names" %in% names(mtcars_out))
     expect_equal_df(mtcars_out, unrowname(mtcars_in)[0, , drop = FALSE])
@@ -196,8 +196,8 @@ spec_sql_create_table <- list(
   #' or `NULL`, the default value.
   create_table_row_names_null = function(ctx, con, table_name = "mtcars") {
     mtcars_in <- datasets::mtcars
-    dbCreateTable(con, "mtcars", mtcars_in, row.names = NULL)
-    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = NULL))
+    dbCreateTable(con, table_name, mtcars_in, row.names = NULL)
+    mtcars_out <- check_df(dbReadTable(con, table_name, row.names = NULL))
 
     expect_false("row_names" %in% names(mtcars_out))
     expect_equal_df(mtcars_out, unrowname(mtcars_in)[0, , drop = FALSE])
@@ -208,11 +208,11 @@ spec_sql_create_table <- list(
     mtcars_in <- datasets::mtcars
 
     #' (in particular `TRUE`,
-    expect_error(dbCreateTable(con, "mtcars", mtcars_in, row.names = TRUE))
+    expect_error(dbCreateTable(con, table_name, mtcars_in, row.names = TRUE))
     #' `NA`,
-    expect_error(dbCreateTable(con, "mtcars", mtcars_in, row.names = NA))
+    expect_error(dbCreateTable(con, table_name, mtcars_in, row.names = NA))
     #' and a string)
-    expect_error(dbCreateTable(con, "mtcars", mtcars_in, row.names = "make_model"))
+    expect_error(dbCreateTable(con, table_name, mtcars_in, row.names = "make_model"))
     #' raise an error.
   },
   #

--- a/R/spec-sql-create-table.R
+++ b/R/spec-sql-create-table.R
@@ -107,40 +107,42 @@ spec_sql_create_table <- list(
   #'
   #' If the `temporary` argument is `TRUE`, the table is not available in a
   #' second connection and is gone after reconnecting.
-  create_temporary_table = function(ctx, con, table_name = "iris") {
+  create_temporary_table = function(ctx, con, table_name = "dbit3") {
     #' Not all backends support this argument.
     if (!isTRUE(ctx$tweaks$temporary_tables)) {
       skip("tweak: temporary_tables")
     }
 
     iris <- get_iris(ctx)[1:30, ]
-    dbCreateTable(con, "iris", iris, temporary = TRUE)
-    iris_out <- check_df(dbReadTable(con, "iris"))
+    dbCreateTable(con, table_name, iris, temporary = TRUE)
+    iris_out <- check_df(dbReadTable(con, table_name))
     expect_equal_df(iris_out, iris[0, , drop = FALSE])
 
     con2 <- local_connection(ctx)
-    expect_error(dbReadTable(con2, "iris"))
+    expect_error(dbReadTable(con2, table_name))
   },
   # second stage
   create_temporary_table = function(con) {
-    expect_error(dbReadTable(con, "iris"))
+    table_name <- "dbit3"
+    expect_error(dbReadTable(con, table_name))
   },
 
   #' A regular, non-temporary table is visible in a second connection
   create_table_visible_in_other_connection = function(ctx, con) {
     iris <- get_iris(ctx)[1:30, ]
 
-    dbCreateTable(con, "iris", iris)
-    iris_out <- check_df(dbReadTable(con, "iris"))
+    table_name <- "dbit4"
+    dbCreateTable(con, table_name, iris)
+    iris_out <- check_df(dbReadTable(con, table_name))
     expect_equal_df(iris_out, iris[0, , drop = FALSE])
 
     con2 <- local_connection(ctx)
-    expect_equal_df(dbReadTable(con2, "iris"), iris[0, , drop = FALSE])
+    expect_equal_df(dbReadTable(con2, table_name), iris[0, , drop = FALSE])
   },
   # second stage
-  create_table_visible_in_other_connection = function(con, table_name = "iris") {
+  create_table_visible_in_other_connection = function(con, table_name = "dbit4") {
     #' and after reconnecting to the database.
-    expect_equal_df(check_df(dbReadTable(con, "iris")), iris[0, , drop = FALSE])
+    expect_equal_df(check_df(dbReadTable(con, table_name)), iris[0, , drop = FALSE])
   },
 
   #'

--- a/R/spec-sql-create-table.R
+++ b/R/spec-sql-create-table.R
@@ -10,12 +10,12 @@ spec_sql_create_table <- list(
 
   #' @return
   #' `dbCreateTable()` returns `TRUE`, invisibly.
-  create_table_return = function(con, table_name = "test") {
+  create_table_return = function(con, table_name = "test2") {
     expect_invisible_true(dbCreateTable(con, table_name, trivial_df()))
   },
 
   #' If the table exists, an error is raised; the remote table remains unchanged.
-  create_table_overwrite = function(con, table_name = "test") {
+  create_table_overwrite = function(con, table_name = "test2") {
     test_in <- trivial_df()
 
     dbCreateTable(con, table_name, test_in)
@@ -38,7 +38,7 @@ spec_sql_create_table <- list(
   },
 
   #' An error is also raised
-  create_table_error = function(ctx, con, table_name = "test") {
+  create_table_error = function(ctx, con, table_name = "test2") {
     test_in <- data.frame(a = 1L)
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbCreateTable(con, NA, test_in))

--- a/R/spec-sql-exists-table.R
+++ b/R/spec-sql-exists-table.R
@@ -11,7 +11,7 @@ spec_sql_exists_table <- list(
   #' @return
   #' `dbExistsTable()` returns a logical scalar, `TRUE` if the table or view
   #' specified by the `name` argument exists, `FALSE` otherwise.
-  exists_table = function(ctx, con, table_name = "dbit5") {
+  exists_table = function(ctx, con, table_name = "dbit05") {
     expect_false(expect_visible(dbExistsTable(con, table_name)))
     iris <- get_iris(ctx)
     dbWriteTable(con, table_name, iris)
@@ -20,7 +20,7 @@ spec_sql_exists_table <- list(
   },
   # second stage
   exists_table = function(ctx, con) {
-    table_name <- "dbit5"
+    table_name <- "dbit05"
     expect_false(expect_visible(dbExistsTable(con, table_name)))
   },
 

--- a/R/spec-sql-exists-table.R
+++ b/R/spec-sql-exists-table.R
@@ -25,7 +25,7 @@ spec_sql_exists_table <- list(
 
   #' 
   #' This includes temporary tables if supported by the database.
-  exists_table_temporary = function(ctx, con, table_name = "test2") {
+  exists_table_temporary = function(ctx, con, table_name) {
     expect_false(expect_visible(dbExistsTable(con, table_name)))
 
     if (isTRUE(ctx$tweaks$temporary_tables)) {
@@ -46,7 +46,7 @@ spec_sql_exists_table <- list(
   },
 
   #' An error is also raised
-  exists_table_error = function(con, table_name = "test2") {
+  exists_table_error = function(con, table_name) {
     dbWriteTable(con, table_name, data.frame(a = 1L))
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbExistsTable(con, NA))

--- a/R/spec-sql-exists-table.R
+++ b/R/spec-sql-exists-table.R
@@ -25,7 +25,7 @@ spec_sql_exists_table <- list(
 
   #' 
   #' This includes temporary tables if supported by the database.
-  exists_table_temporary = function(ctx, con, table_name = "test") {
+  exists_table_temporary = function(ctx, con, table_name = "test2") {
     expect_false(expect_visible(dbExistsTable(con, table_name)))
 
     if (isTRUE(ctx$tweaks$temporary_tables)) {
@@ -46,7 +46,7 @@ spec_sql_exists_table <- list(
   },
 
   #' An error is also raised
-  exists_table_error = function(con, table_name = "test") {
+  exists_table_error = function(con, table_name = "test2") {
     dbWriteTable(con, table_name, data.frame(a = 1L))
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbExistsTable(con, NA))

--- a/R/spec-sql-exists-table.R
+++ b/R/spec-sql-exists-table.R
@@ -11,16 +11,17 @@ spec_sql_exists_table <- list(
   #' @return
   #' `dbExistsTable()` returns a logical scalar, `TRUE` if the table or view
   #' specified by the `name` argument exists, `FALSE` otherwise.
-  exists_table = function(ctx, con, table_name = "iris") {
-    expect_false(expect_visible(dbExistsTable(con, "iris")))
+  exists_table = function(ctx, con, table_name = "dbit5") {
+    expect_false(expect_visible(dbExistsTable(con, table_name)))
     iris <- get_iris(ctx)
-    dbWriteTable(con, "iris", iris)
+    dbWriteTable(con, table_name, iris)
 
-    expect_true(expect_visible(dbExistsTable(con, "iris")))
+    expect_true(expect_visible(dbExistsTable(con, table_name)))
   },
   # second stage
   exists_table = function(ctx, con) {
-    expect_false(expect_visible(dbExistsTable(con, "iris")))
+    table_name <- "dbit5"
+    expect_false(expect_visible(dbExistsTable(con, table_name)))
   },
 
   #' 

--- a/R/spec-sql-list-fields.R
+++ b/R/spec-sql-list-fields.R
@@ -10,7 +10,7 @@ spec_sql_list_fields <- list(
 
   #' @return
   #' `dbListFields()`
-  list_fields = function(ctx, con, table_name = "iris") {
+  list_fields = function(ctx, con, table_name) {
     iris <- get_iris(ctx)
     dbWriteTable(con, table_name, iris)
 

--- a/R/spec-sql-list-fields.R
+++ b/R/spec-sql-list-fields.R
@@ -22,7 +22,7 @@ spec_sql_list_fields <- list(
     expect_identical(fields, names(iris))
   },
   #' This also works for temporary tables if supported by the database.
-  list_fields_temporary = function(ctx, con, table_name = "test2") {
+  list_fields_temporary = function(ctx, con, table_name) {
     if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
       dbWriteTable(con, table_name, data.frame(a = 1L, b = 2L), temporary = TRUE)
       fields <- dbListFields(con, table_name)
@@ -67,7 +67,7 @@ spec_sql_list_fields <- list(
   #'
   #' - a string
   #' - the return value of [dbQuoteIdentifier()]
-  list_fields_quoted = function(con, table_name = "test2") {
+  list_fields_quoted = function(con, table_name) {
     dbWriteTable(con, table_name, data.frame(a = 1L, b = 2L))
     expect_identical(
       dbListFields(con, dbQuoteIdentifier(con, table_name)),
@@ -77,7 +77,7 @@ spec_sql_list_fields <- list(
 
   #' - a value from the `table` column from the return value of
   #'   [dbListObjects()] where `is_prefix` is `FALSE`
-  list_fields_object = function(con, table_name = "test2") {
+  list_fields_object = function(con, table_name) {
     dbWriteTable(con, table_name, data.frame(a = 1L, b = 2L))
     objects <- dbListObjects(con)
     expect_gt(nrow(objects), 0)
@@ -90,7 +90,7 @@ spec_sql_list_fields <- list(
 
   #'
   #' A column named `row_names` is treated like any other column.
-  list_fields_row_names = function(con, table_name = "test2") {
+  list_fields_row_names = function(con, table_name) {
     dbWriteTable(con, table_name, data.frame(a = 1L, row_names = 2L))
     expect_identical(dbListFields(con, table_name), c("a", "row_names"))
   },

--- a/R/spec-sql-list-fields.R
+++ b/R/spec-sql-list-fields.R
@@ -12,9 +12,9 @@ spec_sql_list_fields <- list(
   #' `dbListFields()`
   list_fields = function(ctx, con, table_name = "iris") {
     iris <- get_iris(ctx)
-    dbWriteTable(con, "iris", iris)
+    dbWriteTable(con, table_name, iris)
 
-    fields <- dbListFields(con, "iris")
+    fields <- dbListFields(con, table_name)
     #' returns a character vector
     expect_is(fields, "character")
     #' that enumerates all fields

--- a/R/spec-sql-list-fields.R
+++ b/R/spec-sql-list-fields.R
@@ -22,7 +22,7 @@ spec_sql_list_fields <- list(
     expect_identical(fields, names(iris))
   },
   #' This also works for temporary tables if supported by the database.
-  list_fields_temporary = function(ctx, con, table_name = "test") {
+  list_fields_temporary = function(ctx, con, table_name = "test2") {
     if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
       dbWriteTable(con, table_name, data.frame(a = 1L, b = 2L), temporary = TRUE)
       fields <- dbListFields(con, table_name)
@@ -67,7 +67,7 @@ spec_sql_list_fields <- list(
   #'
   #' - a string
   #' - the return value of [dbQuoteIdentifier()]
-  list_fields_quoted = function(con, table_name = "test") {
+  list_fields_quoted = function(con, table_name = "test2") {
     dbWriteTable(con, table_name, data.frame(a = 1L, b = 2L))
     expect_identical(
       dbListFields(con, dbQuoteIdentifier(con, table_name)),
@@ -77,7 +77,7 @@ spec_sql_list_fields <- list(
 
   #' - a value from the `table` column from the return value of
   #'   [dbListObjects()] where `is_prefix` is `FALSE`
-  list_fields_object = function(con, table_name = "test") {
+  list_fields_object = function(con, table_name = "test2") {
     dbWriteTable(con, table_name, data.frame(a = 1L, b = 2L))
     objects <- dbListObjects(con)
     expect_gt(nrow(objects), 0)
@@ -90,7 +90,7 @@ spec_sql_list_fields <- list(
 
   #'
   #' A column named `row_names` is treated like any other column.
-  list_fields_row_names = function(con, table_name = "test") {
+  list_fields_row_names = function(con, table_name = "test2") {
     dbWriteTable(con, table_name, data.frame(a = 1L, row_names = 2L))
     expect_identical(dbListFields(con, table_name), c("a", "row_names"))
   },

--- a/R/spec-sql-list-objects.R
+++ b/R/spec-sql-list-objects.R
@@ -10,7 +10,7 @@ spec_sql_list_objects <- list(
 
   #' @return
   #' `dbListObjects()`
-  list_objects = function(ctx, con, table_name = "dbit6") {
+  list_objects = function(ctx, con, table_name = "dbit06") {
     objects <- dbListObjects(con)
     #' returns a data frame
     expect_is(objects, "data.frame")
@@ -49,7 +49,7 @@ spec_sql_list_objects <- list(
   list_objects = function(ctx, con) {
     #' As soon a table is removed from the database,
     #' it is also removed from the data frame of database objects.
-    table_name <- "dbit6"
+    table_name <- "dbit06"
 
     objects <- dbListObjects(con)
     quoted_tables <- vapply(objects$table, dbQuoteIdentifier, conn = con, character(1))

--- a/R/spec-sql-list-objects.R
+++ b/R/spec-sql-list-objects.R
@@ -56,7 +56,7 @@ spec_sql_list_objects <- list(
 
   #'
   #' The same applies to temporary objects if supported by the database.
-  list_objects_temporary = function(ctx, con, table_name = "test2") {
+  list_objects_temporary = function(ctx, con, table_name) {
     if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
       dbWriteTable(con, table_name, data.frame(a = 1L), temporary = TRUE)
 

--- a/R/spec-sql-list-objects.R
+++ b/R/spec-sql-list-objects.R
@@ -10,7 +10,7 @@ spec_sql_list_objects <- list(
 
   #' @return
   #' `dbListObjects()`
-  list_objects = function(ctx, con, table_name = "iris") {
+  list_objects = function(ctx, con, table_name = "dbit6") {
     objects <- dbListObjects(con)
     #' returns a data frame
     expect_is(objects, "data.frame")
@@ -30,7 +30,7 @@ spec_sql_list_objects <- list(
     expect_is(objects$is_prefix, "logical")
 
     #' This data frame contains one row for each object (schema, table
-    expect_false("iris" %in% objects)
+    expect_false(table_name %in% objects)
     #' and view)
     # TODO
     #' accessible from the prefix (if passed) or from the global namespace
@@ -38,20 +38,22 @@ spec_sql_list_objects <- list(
 
     #' Tables added with [dbWriteTable()]
     iris <- get_iris(ctx)
-    dbWriteTable(con, "iris", iris)
+    dbWriteTable(con, table_name, iris)
 
     #' are part of the data frame.
     objects <- dbListObjects(con)
     quoted_tables <- vapply(objects$table, dbQuoteIdentifier, conn = con, character(1))
-    expect_true(dbQuoteIdentifier(con, "iris") %in% quoted_tables)
+    expect_true(dbQuoteIdentifier(con, table_name) %in% quoted_tables)
   },
   # second stage
   list_objects = function(ctx, con) {
     #' As soon a table is removed from the database,
     #' it is also removed from the data frame of database objects.
+    table_name <- "dbit6"
+
     objects <- dbListObjects(con)
     quoted_tables <- vapply(objects$table, dbQuoteIdentifier, conn = con, character(1))
-    expect_false(dbQuoteIdentifier(con, "iris") %in% quoted_tables)
+    expect_false(dbQuoteIdentifier(con, table_name) %in% quoted_tables)
   },
 
   #'

--- a/R/spec-sql-list-objects.R
+++ b/R/spec-sql-list-objects.R
@@ -56,7 +56,7 @@ spec_sql_list_objects <- list(
 
   #'
   #' The same applies to temporary objects if supported by the database.
-  list_objects_temporary = function(ctx, con, table_name = "test") {
+  list_objects_temporary = function(ctx, con, table_name = "test2") {
     if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
       dbWriteTable(con, table_name, data.frame(a = 1L), temporary = TRUE)
 

--- a/R/spec-sql-list-tables.R
+++ b/R/spec-sql-list-tables.R
@@ -38,7 +38,7 @@ spec_sql_list_tables <- list(
   },
   #'
   #' The same applies to temporary tables if supported by the database.
-  list_tables_temporary = function(ctx, con, table_name = "test") {
+  list_tables_temporary = function(ctx, con, table_name = "test2") {
     if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
       dbWriteTable(con, table_name, data.frame(a = 1L), temporary = TRUE)
       tables <- dbListTables(con)

--- a/R/spec-sql-list-tables.R
+++ b/R/spec-sql-list-tables.R
@@ -38,7 +38,7 @@ spec_sql_list_tables <- list(
   },
   #'
   #' The same applies to temporary tables if supported by the database.
-  list_tables_temporary = function(ctx, con, table_name = "test2") {
+  list_tables_temporary = function(ctx, con, table_name) {
     if (isTRUE(ctx$tweaks$temporary_tables) && isTRUE(ctx$tweaks$list_temporary_tables)) {
       dbWriteTable(con, table_name, data.frame(a = 1L), temporary = TRUE)
       tables <- dbListTables(con)

--- a/R/spec-sql-list-tables.R
+++ b/R/spec-sql-list-tables.R
@@ -10,7 +10,7 @@ spec_sql_list_tables <- list(
 
   #' @return
   #' `dbListTables()`
-  list_tables = function(ctx, con, table_name = "dbit7") {
+  list_tables = function(ctx, con, table_name = "dbit07") {
     tables <- dbListTables(con)
     #' returns a character vector
     expect_is(tables, "character")
@@ -33,7 +33,7 @@ spec_sql_list_tables <- list(
   list_tables = function(ctx, con) {
     #' As soon a table is removed from the database,
     #' it is also removed from the list of database tables.
-    table_name <- "dbit7"
+    table_name <- "dbit07"
     tables <- dbListTables(con)
     expect_false(table_name %in% tables)
   },

--- a/R/spec-sql-list-tables.R
+++ b/R/spec-sql-list-tables.R
@@ -10,12 +10,12 @@ spec_sql_list_tables <- list(
 
   #' @return
   #' `dbListTables()`
-  list_tables = function(ctx, con, table_name = "iris") {
+  list_tables = function(ctx, con, table_name = "dbit7") {
     tables <- dbListTables(con)
     #' returns a character vector
     expect_is(tables, "character")
     #' that enumerates all tables
-    expect_false("iris" %in% tables)
+    expect_false(table_name %in% tables)
 
     #' and views
     # TODO
@@ -23,18 +23,19 @@ spec_sql_list_tables <- list(
 
     #' Tables added with [dbWriteTable()]
     iris <- get_iris(ctx)
-    dbWriteTable(con, "iris", iris)
+    dbWriteTable(con, table_name, iris)
 
     #' are part of the list.
     tables <- dbListTables(con)
-    expect_true("iris" %in% tables)
+    expect_true(table_name %in% tables)
   },
   # second stage
   list_tables = function(ctx, con) {
     #' As soon a table is removed from the database,
     #' it is also removed from the list of database tables.
+    table_name <- "dbit7"
     tables <- dbListTables(con)
-    expect_false("iris" %in% tables)
+    expect_false(table_name %in% tables)
   },
   #'
   #' The same applies to temporary tables if supported by the database.

--- a/R/spec-sql-read-table.R
+++ b/R/spec-sql-read-table.R
@@ -40,11 +40,12 @@ spec_sql_read_table <- list(
   #' see [sqlColumnToRownames()] for details:
   read_table_row_names_false = function(con) {
     #' - If `FALSE` or `NULL`, the returned data frame doesn't have row names.
+    table_name <- random_table_name()
     for (row.names in list(FALSE, NULL)) {
-      with_remove_test_table(name = "mtcars", {
+      with_remove_test_table(name = table_name, {
         mtcars_in <- datasets::mtcars
-        dbWriteTable(con, "mtcars", mtcars_in, row.names = TRUE)
-        mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = row.names))
+        dbWriteTable(con, table_name, mtcars_in, row.names = TRUE)
+        mtcars_out <- check_df(dbReadTable(con, table_name, row.names = row.names))
 
         expect_true("row_names" %in% names(mtcars_out))
         expect_true(all(mtcars_out$row_names %in% rownames(mtcars_in)))
@@ -59,8 +60,8 @@ spec_sql_read_table <- list(
     row.names <- TRUE
 
     mtcars_in <- datasets::mtcars
-    dbWriteTable(con, "mtcars", mtcars_in, row.names = NA)
-    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = row.names))
+    dbWriteTable(con, table_name, mtcars_in, row.names = NA)
+    mtcars_out <- check_df(dbReadTable(con, table_name, row.names = row.names))
 
     expect_equal_df(mtcars_out, mtcars_in)
   },
@@ -79,8 +80,8 @@ spec_sql_read_table <- list(
     row.names <- NA
 
     mtcars_in <- datasets::mtcars
-    dbWriteTable(con, "mtcars", mtcars_in, row.names = TRUE)
-    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = row.names))
+    dbWriteTable(con, table_name, mtcars_in, row.names = TRUE)
+    mtcars_out <- check_df(dbReadTable(con, table_name, row.names = row.names))
 
     expect_equal_df(mtcars_out, mtcars_in)
   },
@@ -105,8 +106,8 @@ spec_sql_read_table <- list(
     mtcars_in$make_model <- rownames(mtcars_in)
     mtcars_in <- unrowname(mtcars_in)
 
-    dbWriteTable(con, "mtcars", mtcars_in, row.names = FALSE)
-    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = row.names))
+    dbWriteTable(con, table_name, mtcars_in, row.names = FALSE)
+    mtcars_out <- check_df(dbReadTable(con, table_name, row.names = row.names))
 
     expect_false("make_model" %in% names(mtcars_out))
     expect_true(all(mtcars_in$make_model %in% rownames(mtcars_out)))
@@ -129,8 +130,8 @@ spec_sql_read_table <- list(
     #' The default is `row.names = FALSE`.
     #'
     mtcars_in <- datasets::mtcars
-    dbWriteTable(con, "mtcars", mtcars_in, row.names = TRUE)
-    mtcars_out <- check_df(dbReadTable(con, "mtcars"))
+    dbWriteTable(con, table_name, mtcars_in, row.names = TRUE)
+    mtcars_out <- check_df(dbReadTable(con, table_name))
 
     expect_true("row_names" %in% names(mtcars_out))
     expect_true(all(mtcars_out$row_names %in% rownames(mtcars_in)))

--- a/R/spec-sql-read-table.R
+++ b/R/spec-sql-read-table.R
@@ -12,7 +12,7 @@ spec_sql_read_table <- list(
   #' `dbReadTable()` returns a data frame that contains the complete data
   #' from the remote table, effectively the result of calling [dbGetQuery()]
   #' with `SELECT * FROM <name>`.
-  read_table = function(ctx, con, table_name = "iris") {
+  read_table = function(ctx, con, table_name) {
     iris_in <- get_iris(ctx)
     dbWriteTable(con, table_name, iris_in)
     iris_out <- check_df(dbReadTable(con, table_name))
@@ -26,7 +26,7 @@ spec_sql_read_table <- list(
   },
 
   #' An empty table is returned as a data frame with zero rows.
-  read_table_empty = function(ctx, con, table_name = "iris") {
+  read_table_empty = function(ctx, con, table_name) {
     iris_in <- get_iris(ctx)[integer(), ]
     dbWriteTable(con, table_name, iris_in)
     iris_out <- check_df(dbReadTable(con, table_name))
@@ -55,7 +55,7 @@ spec_sql_read_table <- list(
     }
   },
   #
-  read_table_row_names_true_exists = function(con, table_name = "mtcars") {
+  read_table_row_names_true_exists = function(con, table_name) {
     #' - If `TRUE`, a column named "row_names" is converted to row names,
     row.names <- TRUE
 
@@ -66,7 +66,7 @@ spec_sql_read_table <- list(
     expect_equal_df(mtcars_out, mtcars_in)
   },
   #
-  read_table_row_names_true_missing = function(ctx, con, table_name = "iris") {
+  read_table_row_names_true_missing = function(ctx, con, table_name) {
     #'   an error is raised if no such column exists.
     row.names <- TRUE
 
@@ -75,7 +75,7 @@ spec_sql_read_table <- list(
     expect_error(dbReadTable(con, table_name, row.names = row.names))
   },
   #
-  read_table_row_names_na_exists = function(con, table_name = "mtcars") {
+  read_table_row_names_na_exists = function(con, table_name) {
     #' - If `NA`, a column named "row_names" is converted to row names if it exists,
     row.names <- NA
 
@@ -86,7 +86,7 @@ spec_sql_read_table <- list(
     expect_equal_df(mtcars_out, mtcars_in)
   },
   #
-  read_table_row_names_na_missing = function(ctx, con, table_name = "iris") {
+  read_table_row_names_na_missing = function(ctx, con, table_name) {
     #'   otherwise no translation occurs.
     row.names <- NA
 
@@ -97,7 +97,7 @@ spec_sql_read_table <- list(
     expect_equal_df(iris_out, iris_in)
   },
   #
-  read_table_row_names_string_exists = function(con, table_name = "mtcars") {
+  read_table_row_names_string_exists = function(con, table_name) {
     #' - If a string, this specifies the name of the column in the remote table
     #'   that contains the row names,
     row.names <- "make_model"
@@ -115,7 +115,7 @@ spec_sql_read_table <- list(
     expect_equal_df(unrowname(mtcars_out), mtcars_in[names(mtcars_in) != "make_model"])
   },
   #
-  read_table_row_names_string_missing = function(ctx, con, table_name = "iris") {
+  read_table_row_names_string_missing = function(ctx, con, table_name) {
     #'   an error is raised if no such column exists.
     row.names <- "missing"
 
@@ -125,7 +125,7 @@ spec_sql_read_table <- list(
   },
   #'
 
-  read_table_row_names_default = function(con, table_name = "mtcars") {
+  read_table_row_names_default = function(con, table_name) {
     #'
     #' The default is `row.names = FALSE`.
     #'

--- a/R/spec-sql-read-table.R
+++ b/R/spec-sql-read-table.R
@@ -21,7 +21,7 @@ spec_sql_read_table <- list(
   },
 
   #' An error is raised if the table does not exist.
-  read_table_missing = function(con, table_name = "test") {
+  read_table_missing = function(con, table_name = "test2") {
     expect_error(dbReadTable(con, table_name))
   },
 
@@ -138,7 +138,7 @@ spec_sql_read_table <- list(
     expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
   },
   #
-  read_table_check_names = function(ctx, con, table_name = "test") {
+  read_table_check_names = function(ctx, con, table_name = "test2") {
     #' If the database supports identifiers with special characters,
     if (isTRUE(ctx$tweaks$strict_identifier)) {
       skip("tweak: strict_identifier")
@@ -156,7 +156,7 @@ spec_sql_read_table <- list(
     expect_equal_df(test_out, setNames(test_in, names(test_out)))
   },
   #
-  read_table_check_names_false = function(ctx, con, table_name = "test") {
+  read_table_check_names_false = function(ctx, con, table_name = "test2") {
     if (isTRUE(ctx$tweaks$strict_identifier)) {
       skip("tweak: strict_identifier")
     }
@@ -172,21 +172,21 @@ spec_sql_read_table <- list(
 
   #'
   #' An error is raised when calling this method for a closed
-  read_table_closed_connection = function(ctx, con, table_name = "test") {
+  read_table_closed_connection = function(ctx, con, table_name = "test2") {
     dbWriteTable(con, table_name, data.frame(a = 1))
     con2 <- local_closed_connection(ctx = ctx)
     expect_error(dbReadTable(con2, table_name))
   },
 
   #' or invalid connection.
-  read_table_invalid_connection = function(ctx, con, table_name = "test") {
+  read_table_invalid_connection = function(ctx, con, table_name = "test2") {
     dbWriteTable(con, table_name, data.frame(a = 1))
     con2 <- local_invalid_connection(ctx)
     expect_error(dbReadTable(con2, table_name))
   },
 
   #' An error is raised
-  read_table_error = function(ctx, con, table_name = "test") {
+  read_table_error = function(ctx, con, table_name = "test2") {
     dbWriteTable(con, table_name, data.frame(a = 1L))
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbReadTable(con, NA))

--- a/R/spec-sql-read-table.R
+++ b/R/spec-sql-read-table.R
@@ -14,8 +14,8 @@ spec_sql_read_table <- list(
   #' with `SELECT * FROM <name>`.
   read_table = function(ctx, con, table_name = "iris") {
     iris_in <- get_iris(ctx)
-    dbWriteTable(con, "iris", iris_in)
-    iris_out <- check_df(dbReadTable(con, "iris"))
+    dbWriteTable(con, table_name, iris_in)
+    iris_out <- check_df(dbReadTable(con, table_name))
 
     expect_equal_df(iris_out, iris_in)
   },
@@ -28,8 +28,8 @@ spec_sql_read_table <- list(
   #' An empty table is returned as a data frame with zero rows.
   read_table_empty = function(ctx, con, table_name = "iris") {
     iris_in <- get_iris(ctx)[integer(), ]
-    dbWriteTable(con, "iris", iris_in)
-    iris_out <- check_df(dbReadTable(con, "iris"))
+    dbWriteTable(con, table_name, iris_in)
+    iris_out <- check_df(dbReadTable(con, table_name))
 
     expect_equal(nrow(iris_out), 0L)
     expect_equal_df(iris_out, iris_in)
@@ -70,8 +70,8 @@ spec_sql_read_table <- list(
     row.names <- TRUE
 
     iris_in <- get_iris(ctx)
-    dbWriteTable(con, "iris", iris_in, row.names = NA)
-    expect_error(dbReadTable(con, "iris", row.names = row.names))
+    dbWriteTable(con, table_name, iris_in, row.names = NA)
+    expect_error(dbReadTable(con, table_name, row.names = row.names))
   },
   #
   read_table_row_names_na_exists = function(con, table_name = "mtcars") {
@@ -90,8 +90,8 @@ spec_sql_read_table <- list(
     row.names <- NA
 
     iris_in <- get_iris(ctx)
-    dbWriteTable(con, "iris", iris_in, row.names = FALSE)
-    iris_out <- check_df(dbReadTable(con, "iris", row.names = row.names))
+    dbWriteTable(con, table_name, iris_in, row.names = FALSE)
+    iris_out <- check_df(dbReadTable(con, table_name, row.names = row.names))
 
     expect_equal_df(iris_out, iris_in)
   },
@@ -119,8 +119,8 @@ spec_sql_read_table <- list(
     row.names <- "missing"
 
     iris_in <- get_iris(ctx)
-    dbWriteTable(con, "iris", iris_in, row.names = FALSE)
-    expect_error(dbReadTable(con, "iris", row.names = row.names))
+    dbWriteTable(con, table_name, iris_in, row.names = FALSE)
+    expect_error(dbReadTable(con, table_name, row.names = row.names))
   },
   #'
 

--- a/R/spec-sql-read-table.R
+++ b/R/spec-sql-read-table.R
@@ -21,7 +21,7 @@ spec_sql_read_table <- list(
   },
 
   #' An error is raised if the table does not exist.
-  read_table_missing = function(con, table_name = "test2") {
+  read_table_missing = function(con, table_name) {
     expect_error(dbReadTable(con, table_name))
   },
 
@@ -138,7 +138,7 @@ spec_sql_read_table <- list(
     expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
   },
   #
-  read_table_check_names = function(ctx, con, table_name = "test2") {
+  read_table_check_names = function(ctx, con, table_name) {
     #' If the database supports identifiers with special characters,
     if (isTRUE(ctx$tweaks$strict_identifier)) {
       skip("tweak: strict_identifier")
@@ -156,7 +156,7 @@ spec_sql_read_table <- list(
     expect_equal_df(test_out, setNames(test_in, names(test_out)))
   },
   #
-  read_table_check_names_false = function(ctx, con, table_name = "test2") {
+  read_table_check_names_false = function(ctx, con, table_name) {
     if (isTRUE(ctx$tweaks$strict_identifier)) {
       skip("tweak: strict_identifier")
     }
@@ -172,21 +172,21 @@ spec_sql_read_table <- list(
 
   #'
   #' An error is raised when calling this method for a closed
-  read_table_closed_connection = function(ctx, con, table_name = "test2") {
+  read_table_closed_connection = function(ctx, con, table_name) {
     dbWriteTable(con, table_name, data.frame(a = 1))
     con2 <- local_closed_connection(ctx = ctx)
     expect_error(dbReadTable(con2, table_name))
   },
 
   #' or invalid connection.
-  read_table_invalid_connection = function(ctx, con, table_name = "test2") {
+  read_table_invalid_connection = function(ctx, con, table_name) {
     dbWriteTable(con, table_name, data.frame(a = 1))
     con2 <- local_invalid_connection(ctx)
     expect_error(dbReadTable(con2, table_name))
   },
 
   #' An error is raised
-  read_table_error = function(ctx, con, table_name = "test2") {
+  read_table_error = function(ctx, con, table_name) {
     dbWriteTable(con, table_name, data.frame(a = 1L))
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbReadTable(con, NA))

--- a/R/spec-sql-remove-table.R
+++ b/R/spec-sql-remove-table.R
@@ -12,9 +12,9 @@ spec_sql_remove_table <- list(
   #' `dbRemoveTable()` returns `TRUE`, invisibly.
   remove_table_return = function(ctx, con, table_name = "iris") {
     iris <- get_iris(ctx)
-    dbWriteTable(con, "iris", iris)
+    dbWriteTable(con, table_name, iris)
 
-    expect_invisible_true(dbRemoveTable(con, "iris"))
+    expect_invisible_true(dbRemoveTable(con, table_name))
   },
 
   #' If the table does not exist, an error is raised.

--- a/R/spec-sql-remove-table.R
+++ b/R/spec-sql-remove-table.R
@@ -18,7 +18,7 @@ spec_sql_remove_table <- list(
   },
 
   #' If the table does not exist, an error is raised.
-  remove_table_missing = function(con, table_name = "test") {
+  remove_table_missing = function(con, table_name = "test2") {
     expect_error(dbRemoveTable(con, table_name))
   },
 
@@ -26,21 +26,21 @@ spec_sql_remove_table <- list(
   #'
   #'
   #' An error is raised when calling this method for a closed
-  remove_table_closed_connection = function(ctx, con, table_name = "test") {
+  remove_table_closed_connection = function(ctx, con, table_name = "test2") {
     dbWriteTable(con, table_name, data.frame(a = 1))
     con2 <- local_closed_connection(ctx = ctx)
     expect_error(dbRemoveTable(con2, table_name))
   },
 
   #' or invalid connection.
-  remove_table_invalid_connection = function(ctx, con, table_name = "test") {
+  remove_table_invalid_connection = function(ctx, con, table_name = "test2") {
     dbWriteTable(con, table_name, data.frame(a = 1))
     con2 <- local_invalid_connection(ctx)
     expect_error(dbRemoveTable(con2, table_name))
   },
 
   #' An error is also raised
-  remove_table_error = function(con, table_name = "test") {
+  remove_table_error = function(con, table_name = "test2") {
     dbWriteTable(con, table_name, data.frame(a = 1L))
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbRemoveTable(con, NA))
@@ -61,7 +61,7 @@ spec_sql_remove_table <- list(
   #'
   #' If `temporary` is `TRUE`, the call to `dbRemoveTable()`
   #' will consider only temporary tables.
-  remove_table_temporary_arg = function(ctx, con, table_name = "test") {
+  remove_table_temporary_arg = function(ctx, con, table_name = "test2") {
     #' Not all backends support this argument.
     if (!isTRUE(ctx$tweaks$temporary_tables)) {
       skip("tweak: temporary_tables")
@@ -79,7 +79,7 @@ spec_sql_remove_table <- list(
   #'
   #' If `fail_if_missing` is `FALSE`, the call to `dbRemoveTable()`
   #' succeeds if the table does not exist.
-  remove_table_missing_succeed = function(con, table_name = "test") {
+  remove_table_missing_succeed = function(con, table_name = "test2") {
     expect_error(dbRemoveTable(con, table_name, fail_if_missing = FALSE), NA)
   },
 
@@ -87,7 +87,7 @@ spec_sql_remove_table <- list(
   #' A table removed by `dbRemoveTable()` doesn't appear in the list of tables
   #' returned by [dbListTables()],
   #' and [dbExistsTable()] returns `FALSE`.
-  remove_table_list = function(con, table_name = "test") {
+  remove_table_list = function(con, table_name = "test2") {
     dbWriteTable(con, table_name, data.frame(a = 1L))
     expect_true(table_name %in% dbListTables(con))
     expect_true(dbExistsTable(con, table_name))
@@ -98,7 +98,7 @@ spec_sql_remove_table <- list(
   },
 
   #' The removal propagates immediately to other connections to the same database.
-  remove_table_other_con = function(ctx, con, table_name = "test") {
+  remove_table_other_con = function(ctx, con, table_name = "test2") {
     con2 <- local_connection(ctx)
     dbWriteTable(con, table_name, data.frame(a = 1L))
     expect_true(table_name %in% dbListTables(con2))
@@ -110,7 +110,7 @@ spec_sql_remove_table <- list(
   },
 
   #' This function can also be used to remove a temporary table.
-  remove_table_temporary = function(ctx, con, table_name = "test") {
+  remove_table_temporary = function(ctx, con, table_name = "test2") {
     if (!isTRUE(ctx$tweaks$temporary_tables)) {
       skip("tweak: temporary_tables")
     }

--- a/R/spec-sql-remove-table.R
+++ b/R/spec-sql-remove-table.R
@@ -18,7 +18,7 @@ spec_sql_remove_table <- list(
   },
 
   #' If the table does not exist, an error is raised.
-  remove_table_missing = function(con, table_name = "test2") {
+  remove_table_missing = function(con, table_name) {
     expect_error(dbRemoveTable(con, table_name))
   },
 
@@ -26,21 +26,21 @@ spec_sql_remove_table <- list(
   #'
   #'
   #' An error is raised when calling this method for a closed
-  remove_table_closed_connection = function(ctx, con, table_name = "test2") {
+  remove_table_closed_connection = function(ctx, con, table_name) {
     dbWriteTable(con, table_name, data.frame(a = 1))
     con2 <- local_closed_connection(ctx = ctx)
     expect_error(dbRemoveTable(con2, table_name))
   },
 
   #' or invalid connection.
-  remove_table_invalid_connection = function(ctx, con, table_name = "test2") {
+  remove_table_invalid_connection = function(ctx, con, table_name) {
     dbWriteTable(con, table_name, data.frame(a = 1))
     con2 <- local_invalid_connection(ctx)
     expect_error(dbRemoveTable(con2, table_name))
   },
 
   #' An error is also raised
-  remove_table_error = function(con, table_name = "test2") {
+  remove_table_error = function(con, table_name) {
     dbWriteTable(con, table_name, data.frame(a = 1L))
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbRemoveTable(con, NA))
@@ -61,7 +61,7 @@ spec_sql_remove_table <- list(
   #'
   #' If `temporary` is `TRUE`, the call to `dbRemoveTable()`
   #' will consider only temporary tables.
-  remove_table_temporary_arg = function(ctx, con, table_name = "test2") {
+  remove_table_temporary_arg = function(ctx, con, table_name) {
     #' Not all backends support this argument.
     if (!isTRUE(ctx$tweaks$temporary_tables)) {
       skip("tweak: temporary_tables")
@@ -79,7 +79,7 @@ spec_sql_remove_table <- list(
   #'
   #' If `fail_if_missing` is `FALSE`, the call to `dbRemoveTable()`
   #' succeeds if the table does not exist.
-  remove_table_missing_succeed = function(con, table_name = "test2") {
+  remove_table_missing_succeed = function(con, table_name) {
     expect_error(dbRemoveTable(con, table_name, fail_if_missing = FALSE), NA)
   },
 
@@ -87,7 +87,7 @@ spec_sql_remove_table <- list(
   #' A table removed by `dbRemoveTable()` doesn't appear in the list of tables
   #' returned by [dbListTables()],
   #' and [dbExistsTable()] returns `FALSE`.
-  remove_table_list = function(con, table_name = "test2") {
+  remove_table_list = function(con, table_name) {
     dbWriteTable(con, table_name, data.frame(a = 1L))
     expect_true(table_name %in% dbListTables(con))
     expect_true(dbExistsTable(con, table_name))
@@ -98,7 +98,7 @@ spec_sql_remove_table <- list(
   },
 
   #' The removal propagates immediately to other connections to the same database.
-  remove_table_other_con = function(ctx, con, table_name = "test2") {
+  remove_table_other_con = function(ctx, con, table_name) {
     con2 <- local_connection(ctx)
     dbWriteTable(con, table_name, data.frame(a = 1L))
     expect_true(table_name %in% dbListTables(con2))
@@ -110,7 +110,7 @@ spec_sql_remove_table <- list(
   },
 
   #' This function can also be used to remove a temporary table.
-  remove_table_temporary = function(ctx, con, table_name = "test2") {
+  remove_table_temporary = function(ctx, con, table_name) {
     if (!isTRUE(ctx$tweaks$temporary_tables)) {
       skip("tweak: temporary_tables")
     }

--- a/R/spec-sql-remove-table.R
+++ b/R/spec-sql-remove-table.R
@@ -10,7 +10,7 @@ spec_sql_remove_table <- list(
 
   #' @return
   #' `dbRemoveTable()` returns `TRUE`, invisibly.
-  remove_table_return = function(ctx, con, table_name = "iris") {
+  remove_table_return = function(ctx, con, table_name) {
     iris <- get_iris(ctx)
     dbWriteTable(con, table_name, iris)
 

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -180,7 +180,7 @@ spec_sql_write_table <- list(
   #'
   #' If the `temporary` argument is `TRUE`, the table is not available in a
   #' second connection and is gone after reconnecting.
-  temporary_table = function(ctx, con, table_name = "dbit8") {
+  temporary_table = function(ctx, con, table_name = "dbit08") {
     #' Not all backends support this argument.
     if (!isTRUE(ctx$tweaks$temporary_tables)) {
       skip("tweak: temporary_tables")
@@ -200,7 +200,7 @@ spec_sql_write_table <- list(
       skip("tweak: temporary_tables")
     }
 
-    table_name <- "dbit8"
+    table_name <- "dbit08"
     expect_error(dbReadTable(con, table_name))
   },
 
@@ -208,7 +208,7 @@ spec_sql_write_table <- list(
   table_visible_in_other_connection = function(ctx, con) {
     iris30 <- get_iris(ctx)[1:30, ]
 
-    table_name <- "dbit9"
+    table_name <- "dbit09"
 
     dbWriteTable(con, table_name, iris30)
     iris_out <- check_df(dbReadTable(con, table_name))
@@ -218,7 +218,7 @@ spec_sql_write_table <- list(
     expect_equal_df(dbReadTable(con2, table_name), iris30)
   },
   # second stage
-  table_visible_in_other_connection = function(ctx, con, table_name = "dbit9") {
+  table_visible_in_other_connection = function(ctx, con, table_name = "dbit09") {
     #' and after reconnecting to the database.
     iris30 <- get_iris(ctx)[1:30, ]
 

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -11,12 +11,12 @@ spec_sql_write_table <- list(
 
   #' @return
   #' `dbWriteTable()` returns `TRUE`, invisibly.
-  write_table_return = function(con, table_name = "test2") {
+  write_table_return = function(con, table_name) {
     expect_invisible_true(dbWriteTable(con, table_name, data.frame(a = 1L)))
   },
 
   #' If the table exists, and both `append` and `overwrite` arguments are unset,
-  write_table_overwrite = function(con, table_name = "test2") {
+  write_table_overwrite = function(con, table_name) {
     test_in <- data.frame(a = 1L)
     dbWriteTable(con, table_name, test_in)
     expect_error(dbWriteTable(con, table_name, data.frame(a = 2L)))
@@ -28,7 +28,7 @@ spec_sql_write_table <- list(
   #' or `append = TRUE` and the data frame with the new data has different
   #' column names,
   #' an error is raised; the remote table remains unchanged.
-  write_table_append_incompatible = function(con, table_name = "test2") {
+  write_table_append_incompatible = function(con, table_name) {
     test_in <- data.frame(a = 1L)
     dbWriteTable(con, table_name, test_in)
     expect_error(dbWriteTable(con, table_name, data.frame(b = 2L), append = TRUE))
@@ -49,7 +49,7 @@ spec_sql_write_table <- list(
   },
 
   #' An error is also raised
-  write_table_error = function(ctx, con, table_name = "test2") {
+  write_table_error = function(ctx, con, table_name) {
     test_in <- data.frame(a = 1L)
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbWriteTable(con, NA, test_in))

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -11,12 +11,12 @@ spec_sql_write_table <- list(
 
   #' @return
   #' `dbWriteTable()` returns `TRUE`, invisibly.
-  write_table_return = function(con, table_name = "test") {
+  write_table_return = function(con, table_name = "test2") {
     expect_invisible_true(dbWriteTable(con, table_name, data.frame(a = 1L)))
   },
 
   #' If the table exists, and both `append` and `overwrite` arguments are unset,
-  write_table_overwrite = function(con, table_name = "test") {
+  write_table_overwrite = function(con, table_name = "test2") {
     test_in <- data.frame(a = 1L)
     dbWriteTable(con, table_name, test_in)
     expect_error(dbWriteTable(con, table_name, data.frame(a = 2L)))
@@ -28,7 +28,7 @@ spec_sql_write_table <- list(
   #' or `append = TRUE` and the data frame with the new data has different
   #' column names,
   #' an error is raised; the remote table remains unchanged.
-  write_table_append_incompatible = function(con, table_name = "test") {
+  write_table_append_incompatible = function(con, table_name = "test2") {
     test_in <- data.frame(a = 1L)
     dbWriteTable(con, table_name, test_in)
     expect_error(dbWriteTable(con, table_name, data.frame(b = 2L), append = TRUE))
@@ -49,7 +49,7 @@ spec_sql_write_table <- list(
   },
 
   #' An error is also raised
-  write_table_error = function(ctx, con, table_name = "test") {
+  write_table_error = function(ctx, con, table_name = "test2") {
     test_in <- data.frame(a = 1L)
     #' if `name` cannot be processed with [dbQuoteIdentifier()]
     expect_error(dbWriteTable(con, NA, test_in))

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -549,11 +549,12 @@ spec_sql_write_table <- list(
   #' see [sqlRownamesToColumn()] for details:
   write_table_row_names_false = function(ctx, con) {
     #' - If `FALSE` or `NULL`, row names are ignored.
+    table_name <- random_table_name()
     for (row.names in list(FALSE, NULL)) {
-      with_remove_test_table(name = "mtcars", {
+      with_remove_test_table(name = table_name, {
         mtcars_in <- datasets::mtcars
-        dbWriteTable(con, "mtcars", mtcars_in, row.names = row.names)
-        mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
+        dbWriteTable(con, table_name, mtcars_in, row.names = row.names)
+        mtcars_out <- check_df(dbReadTable(con, table_name, row.names = FALSE))
 
         expect_false("row_names" %in% names(mtcars_out))
         expect_equal_df(mtcars_out, unrowname(mtcars_in))
@@ -566,8 +567,8 @@ spec_sql_write_table <- list(
     row.names <- TRUE
 
     mtcars_in <- datasets::mtcars
-    dbWriteTable(con, "mtcars", mtcars_in, row.names = row.names)
-    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
+    dbWriteTable(con, table_name, mtcars_in, row.names = row.names)
+    mtcars_out <- check_df(dbReadTable(con, table_name, row.names = FALSE))
 
     expect_true("row_names" %in% names(mtcars_out))
     expect_true(all(rownames(mtcars_in) %in% mtcars_out$row_names))
@@ -594,8 +595,8 @@ spec_sql_write_table <- list(
     row.names <- NA
 
     mtcars_in <- datasets::mtcars
-    dbWriteTable(con, "mtcars", mtcars_in, row.names = row.names)
-    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
+    dbWriteTable(con, table_name, mtcars_in, row.names = row.names)
+    mtcars_out <- check_df(dbReadTable(con, table_name, row.names = FALSE))
 
     expect_true("row_names" %in% names(mtcars_out))
     expect_true(all(rownames(mtcars_in) %in% mtcars_out$row_names))
@@ -621,8 +622,8 @@ spec_sql_write_table <- list(
 
     mtcars_in <- datasets::mtcars
 
-    dbWriteTable(con, "mtcars", mtcars_in, row.names = row.names)
-    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
+    dbWriteTable(con, table_name, mtcars_in, row.names = row.names)
+    mtcars_out <- check_df(dbReadTable(con, table_name, row.names = FALSE))
 
     expect_true("make_model" %in% names(mtcars_out))
     expect_true(all(mtcars_out$make_model %in% rownames(mtcars_in)))
@@ -648,8 +649,8 @@ spec_sql_write_table <- list(
     #'
     #' The default is `row.names = FALSE`.
     mtcars_in <- datasets::mtcars
-    dbWriteTable(con, "mtcars", mtcars_in)
-    mtcars_out <- check_df(dbReadTable(con, "mtcars", row.names = FALSE))
+    dbWriteTable(con, table_name, mtcars_in)
+    mtcars_out <- check_df(dbReadTable(con, table_name, row.names = FALSE))
 
     expect_false("row_names" %in% names(mtcars_out))
     expect_equal_df(mtcars_out, unrowname(mtcars_in))

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -136,7 +136,7 @@ spec_sql_write_table <- list(
   #'
   #' If the `overwrite` argument is `TRUE`, an existing table of the same name
   #' will be overwritten.
-  overwrite_table = function(ctx, con, table_name = "iris") {
+  overwrite_table = function(ctx, con, table_name) {
     iris <- get_iris(ctx)
     dbWriteTable(con, table_name, iris)
     expect_error(
@@ -148,7 +148,7 @@ spec_sql_write_table <- list(
   },
 
   #' This argument doesn't change behavior if the table does not exist yet.
-  overwrite_table_missing = function(ctx, con, table_name = "iris") {
+  overwrite_table_missing = function(ctx, con, table_name) {
     iris_in <- get_iris(ctx)
     expect_error(
       dbWriteTable(con, table_name, iris[1:10, ], overwrite = TRUE),
@@ -161,7 +161,7 @@ spec_sql_write_table <- list(
   #'
   #' If the `append` argument is `TRUE`, the rows in an existing table are
   #' preserved, and the new data are appended.
-  append_table = function(ctx, con, table_name = "iris") {
+  append_table = function(ctx, con, table_name) {
     iris <- get_iris(ctx)
     dbWriteTable(con, table_name, iris)
     expect_error(dbWriteTable(con, table_name, iris[1:10, ], append = TRUE), NA)
@@ -170,7 +170,7 @@ spec_sql_write_table <- list(
   },
 
   #' If the table doesn't exist yet, it is created.
-  append_table_new = function(ctx, con, table_name = "iris") {
+  append_table_new = function(ctx, con, table_name) {
     iris <- get_iris(ctx)
     expect_error(dbWriteTable(con, table_name, iris[1:10, ], append = TRUE), NA)
     iris_out <- check_df(dbReadTable(con, table_name))
@@ -562,7 +562,7 @@ spec_sql_write_table <- list(
     }
   },
   #
-  write_table_row_names_true_exists = function(ctx, con, table_name = "mtcars") {
+  write_table_row_names_true_exists = function(ctx, con, table_name) {
     #' - If `TRUE`, row names are converted to a column named "row_names",
     row.names <- TRUE
 
@@ -576,7 +576,7 @@ spec_sql_write_table <- list(
     expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
   },
   #
-  write_table_row_names_true_missing = function(ctx, con, table_name = "iris") {
+  write_table_row_names_true_missing = function(ctx, con, table_name) {
     #'   even if the input data frame only has natural row names from 1 to `nrow(...)`.
     row.names <- TRUE
 
@@ -590,7 +590,7 @@ spec_sql_write_table <- list(
     expect_equal_df(iris_out[names(iris_out) != "row_names"], iris_in)
   },
   #
-  write_table_row_names_na_exists = function(ctx, con, table_name = "mtcars") {
+  write_table_row_names_na_exists = function(ctx, con, table_name) {
     #' - If `NA`, a column named "row_names" is created if the data has custom row names,
     row.names <- NA
 
@@ -604,7 +604,7 @@ spec_sql_write_table <- list(
     expect_equal_df(mtcars_out[names(mtcars_out) != "row_names"], unrowname(mtcars_in))
   },
   #
-  write_table_row_names_na_missing = function(ctx, con, table_name = "iris") {
+  write_table_row_names_na_missing = function(ctx, con, table_name) {
     #'   no extra column is created in the case of natural row names.
     row.names <- NA
 
@@ -615,7 +615,7 @@ spec_sql_write_table <- list(
     expect_equal_df(iris_out, iris_in)
   },
   #
-  write_table_row_names_string_exists = function(ctx, con, table_name = "mtcars") {
+  write_table_row_names_string_exists = function(ctx, con, table_name) {
     row.names <- "make_model"
     #' - If a string, this specifies the name of the column in the remote table
     #'   that contains the row names,
@@ -631,7 +631,7 @@ spec_sql_write_table <- list(
     expect_equal_df(mtcars_out[names(mtcars_out) != "make_model"], unrowname(mtcars_in))
   },
   #
-  write_table_row_names_string_missing = function(ctx, con, table_name = "iris") {
+  write_table_row_names_string_missing = function(ctx, con, table_name) {
     row.names <- "seq"
     #'   even if the input data frame only has natural row names.
 
@@ -645,7 +645,7 @@ spec_sql_write_table <- list(
     expect_equal_df(iris_out[names(iris_out) != "seq"], iris_in)
   },
   #
-  write_table_row_names_default = function(ctx, con, table_name = "mtcars") {
+  write_table_row_names_default = function(ctx, con, table_name) {
     #'
     #' The default is `row.names = FALSE`.
     mtcars_in <- datasets::mtcars

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -684,8 +684,8 @@ test_table_roundtrip_one <- function(con, tbl_in, tbl_expected = tbl_in, transfo
       dbWriteTable(con, name, tbl_in, field.types = field.types)
     }
 
-    tbl_out <- check_df(dbReadTable(con, name, check.names = FALSE))
-    tbl_out <- transform(tbl_out)
+    tbl_read <- check_df(dbReadTable(con, name, check.names = FALSE))
+    tbl_out <- transform(tbl_read)
     expect_equal_df(tbl_out, tbl_expected)
   })
 }

--- a/R/spec-transaction-begin-commit-rollback.R
+++ b/R/spec-transaction-begin-commit-rollback.R
@@ -91,7 +91,7 @@ spec_transaction_begin_commit_rollback <- list(
   begin_write_commit = function(con) {
     #' For example, a record that is missing when the transaction is started
 
-    table_name <- "test"
+    table_name <- "dbit0"
     dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
 
     dbBegin(con)
@@ -110,7 +110,7 @@ spec_transaction_begin_commit_rollback <- list(
     expect_equal(check_df(dbReadTable(con, table_name)), data.frame(a = 0:1))
   },
   # second stage
-  begin_write_commit = function(con, table_name = "test") {
+  begin_write_commit = function(con, table_name = "dbit0") {
     #' and also in a new connection.
     expect_true(dbExistsTable(con, table_name))
     expect_equal(check_df(dbReadTable(con, table_name)), data.frame(a = 0:1))
@@ -126,7 +126,7 @@ spec_transaction_begin_commit_rollback <- list(
 
   #' All data written in such a transaction must be removed after the
   #' transaction is rolled back.
-  begin_write_rollback = function(con, table_name = "test") {
+  begin_write_rollback = function(con, table_name = "test2") {
     #' For example, a record that is missing when the transaction is started
     dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
 
@@ -141,7 +141,7 @@ spec_transaction_begin_commit_rollback <- list(
   },
   #
   begin_write_disconnect = function(con) {
-    table_name <- "test"
+    table_name <- "dbit1"
     #'
     #' Disconnection from a connection with an open transaction
     dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
@@ -151,7 +151,7 @@ spec_transaction_begin_commit_rollback <- list(
     dbWriteTable(con, table_name, data.frame(a = 1L), append = TRUE)
   },
   #
-  begin_write_disconnect = function(con, table_name = "test") {
+  begin_write_disconnect = function(con, table_name = "dbit1") {
     #' effectively rolls back the transaction.
     #' All data written in such a transaction must be removed after the
     #' transaction is rolled back.

--- a/R/spec-transaction-begin-commit-rollback.R
+++ b/R/spec-transaction-begin-commit-rollback.R
@@ -97,7 +97,7 @@ spec_transaction_begin_commit_rollback <- list(
     dbBegin(con)
     with_rollback_on_error({
       #' but is created during the transaction
-      dbExecute(con, paste0("INSERT INTO test (a) VALUES (1)"))
+      dbExecute(con, paste0("INSERT INTO ", table_name, " (a) VALUES (1)"))
 
       #' must exist
       expect_equal(check_df(dbReadTable(con, table_name)), data.frame(a = 0:1))

--- a/R/spec-transaction-begin-commit-rollback.R
+++ b/R/spec-transaction-begin-commit-rollback.R
@@ -126,7 +126,7 @@ spec_transaction_begin_commit_rollback <- list(
 
   #' All data written in such a transaction must be removed after the
   #' transaction is rolled back.
-  begin_write_rollback = function(con, table_name = "test2") {
+  begin_write_rollback = function(con, table_name) {
     #' For example, a record that is missing when the transaction is started
     dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
 

--- a/R/spec-transaction-begin-commit-rollback.R
+++ b/R/spec-transaction-begin-commit-rollback.R
@@ -91,7 +91,7 @@ spec_transaction_begin_commit_rollback <- list(
   begin_write_commit = function(con) {
     #' For example, a record that is missing when the transaction is started
 
-    table_name <- "dbit0"
+    table_name <- "dbit00"
     dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
 
     dbBegin(con)
@@ -110,7 +110,7 @@ spec_transaction_begin_commit_rollback <- list(
     expect_equal(check_df(dbReadTable(con, table_name)), data.frame(a = 0:1))
   },
   # second stage
-  begin_write_commit = function(con, table_name = "dbit0") {
+  begin_write_commit = function(con, table_name = "dbit00") {
     #' and also in a new connection.
     expect_true(dbExistsTable(con, table_name))
     expect_equal(check_df(dbReadTable(con, table_name)), data.frame(a = 0:1))
@@ -141,7 +141,7 @@ spec_transaction_begin_commit_rollback <- list(
   },
   #
   begin_write_disconnect = function(con) {
-    table_name <- "dbit1"
+    table_name <- "dbit01"
     #'
     #' Disconnection from a connection with an open transaction
     dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
@@ -151,7 +151,7 @@ spec_transaction_begin_commit_rollback <- list(
     dbWriteTable(con, table_name, data.frame(a = 1L), append = TRUE)
   },
   #
-  begin_write_disconnect = function(con, table_name = "dbit1") {
+  begin_write_disconnect = function(con, table_name = "dbit01") {
     #' effectively rolls back the transaction.
     #' All data written in such a transaction must be removed after the
     #' transaction is rolled back.

--- a/R/spec-transaction-with-transaction.R
+++ b/R/spec-transaction-with-transaction.R
@@ -38,7 +38,7 @@ spec_transaction_with_transaction <- list(
   #' `dbWithTransaction()` initiates a transaction with `dbBegin()`, executes
   #' the code given in the `code` argument, and commits the transaction with
   #' [dbCommit()].
-  with_transaction_success = function(con, table_name = "test2") {
+  with_transaction_success = function(con, table_name) {
     dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
 
     dbWithTransaction(
@@ -54,7 +54,7 @@ spec_transaction_with_transaction <- list(
 
   #' If the code raises an error, the transaction is instead aborted with
   #' [dbRollback()], and the error is propagated.
-  with_transaction_failure = function(con, table_name = "test2") {
+  with_transaction_failure = function(con, table_name) {
     dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
 
     name <- random_table_name()
@@ -75,7 +75,7 @@ spec_transaction_with_transaction <- list(
 
   #' If the code calls `dbBreak()`, execution of the code stops and the
   #' transaction is silently aborted.
-  with_transaction_break = function(con, table_name = "test2") {
+  with_transaction_break = function(con, table_name) {
     dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
 
     expect_error(

--- a/R/spec-transaction-with-transaction.R
+++ b/R/spec-transaction-with-transaction.R
@@ -38,7 +38,7 @@ spec_transaction_with_transaction <- list(
   #' `dbWithTransaction()` initiates a transaction with `dbBegin()`, executes
   #' the code given in the `code` argument, and commits the transaction with
   #' [dbCommit()].
-  with_transaction_success = function(con, table_name = "test") {
+  with_transaction_success = function(con, table_name = "test2") {
     dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
 
     dbWithTransaction(
@@ -54,7 +54,7 @@ spec_transaction_with_transaction <- list(
 
   #' If the code raises an error, the transaction is instead aborted with
   #' [dbRollback()], and the error is propagated.
-  with_transaction_failure = function(con, table_name = "test") {
+  with_transaction_failure = function(con, table_name = "test2") {
     dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
 
     name <- random_table_name()
@@ -75,7 +75,7 @@ spec_transaction_with_transaction <- list(
 
   #' If the code calls `dbBreak()`, execution of the code stops and the
   #' transaction is silently aborted.
-  with_transaction_break = function(con, table_name = "test") {
+  with_transaction_break = function(con, table_name = "test2") {
     dbWriteTable(con, table_name, data.frame(a = 0L), overwrite = TRUE)
 
     expect_error(

--- a/R/utils.R
+++ b/R/utils.R
@@ -131,7 +131,7 @@ unrowname <- function(x) {
 }
 
 random_table_name <- function(n = 10) {
-  paste0(sample(letters, n, replace = TRUE), collapse = "")
+  paste0("dbit", paste(sample(letters, n, replace = TRUE), collapse = ""))
 }
 
 compact <- function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -131,6 +131,7 @@ unrowname <- function(x) {
 }
 
 random_table_name <- function(n = 10) {
+  # FIXME: Use parallel-safe sequence of numbers
   paste0("dbit", paste(sample(letters, n, replace = TRUE), collapse = ""))
 }
 

--- a/revdep-dev/Makefile
+++ b/revdep-dev/Makefile
@@ -3,12 +3,11 @@ all: test
 TESTTHAT_REPORTER ?= 'check'
 
 REVDEP := RMariaDB RSQLite RPostgres RKazam
-LOAD_TARGETS := $(patsubst %,load-%,${REVDEP})
 TEST_TARGETS := $(patsubst %,test-%,${REVDEP})
 
 LIB_DIR := $(shell Rscript -e "cat(.libPaths()[1])")
 
-${LIB_DIR}/DBItest/DESCRIPTION: ../R/*.R ../DESCRIPTION ${LOAD_TARGETS}
+${LIB_DIR}/DBItest/DESCRIPTION: ../R/*.R ../DESCRIPTION
 	R CMD INSTALL ..
 
 install: ${LIB_DIR}/DBItest/DESCRIPTION
@@ -23,14 +22,7 @@ bigrquery:
 
 test: ${TEST_TARGETS}
 
-safe-load-%:
-	Rscript -e "devtools::load_all('$*')"
-
-# Necessary because of https://github.com/hadley/devtools/issues/1070
-load-%: %
-	make --quiet -j1 safe-load-$*
-
-test-%: install load-% %
+test-%: install %
 	Rscript -e "options(crayon.enabled=TRUE); devtools::test('$*', filter = 'DBItest', reporter = ${TESTTHAT_REPORTER})"
 
 clean:

--- a/revdep-dev/Makefile
+++ b/revdep-dev/Makefile
@@ -3,11 +3,12 @@ all: test
 TESTTHAT_REPORTER ?= 'check'
 
 REVDEP := RMariaDB RSQLite RPostgres RKazam
+LOAD_TARGETS := $(patsubst %,load-%,${REVDEP})
 TEST_TARGETS := $(patsubst %,test-%,${REVDEP})
 
 LIB_DIR := $(shell Rscript -e "cat(.libPaths()[1])")
 
-${LIB_DIR}/DBItest/DESCRIPTION: ../R/*.R ../DESCRIPTION
+${LIB_DIR}/DBItest/DESCRIPTION: ../R/*.R ../DESCRIPTION ${LOAD_TARGETS}
 	R CMD INSTALL ..
 
 install: ${LIB_DIR}/DBItest/DESCRIPTION
@@ -22,7 +23,14 @@ bigrquery:
 
 test: ${TEST_TARGETS}
 
-test-%: install %
+safe-load-%:
+	Rscript -e "devtools::load_all('$*')"
+
+# Necessary because of https://github.com/hadley/devtools/issues/1070
+load-%: %
+	make --quiet -j1 safe-load-$*
+
+test-%: install load-% %
 	Rscript -e "options(crayon.enabled=TRUE); devtools::test('$*', filter = 'DBItest', reporter = ${TESTTHAT_REPORTER})"
 
 clean:

--- a/revdep-dev/Makefile
+++ b/revdep-dev/Makefile
@@ -23,7 +23,7 @@ bigrquery:
 test: ${TEST_TARGETS}
 
 test-%: install %
-	Rscript -e "options(crayon.enabled=TRUE); devtools::test('$*', filter = 'DBItest', reporter = ${TESTTHAT_REPORTER})"
+	Rscript -e "options(crayon.enabled=TRUE); devtools::test('$*', filter = 'DBItest', stop_on_failure = TRUE, reporter = ${TESTTHAT_REPORTER})"
 
 clean:
 	rm -rf ${REVDEP}


### PR DESCRIPTION
to reduce interdependencies between tests.