### PR TITLE
testthat 3.0.0 compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,8 @@ Imports:
     R6,
     rlang (>= 0.2.0),
     testthat (>= 2.0.0),
-    withr
+    withr,
+    vctrs
 Suggests: 
     dblog,
     debugme,


### PR DESCRIPTION
- Wrap pre-test code in `test_that()`
- Make test names unique