### PR TITLE
chore: Add new `dbFetchArrowChunk()` generic 

### DIFF
--- a/R/dbi.R
+++ b/R/dbi.R
@@ -39,6 +39,7 @@ dbi_generics <- function(version) {
       "dbGetQueryArrow",
       "dbAppendTableArrow",
       "dbFetchArrow",
+      "dbFetchArrowChunk",
       "dbWriteTableArrow",
       "dbSendQueryArrow",
       "dbReadTableArrow",

--- a/R/generics.R
+++ b/R/generics.R
@@ -19,6 +19,7 @@ all_dbi_generics <- function() {
     "dbExistsTable",
     "dbFetch",
     "dbFetchArrow",
+    "dbFetchArrowChunk",
     "dbGetInfo",
     "dbGetQuery",
     "dbGetQueryArrow",


### PR DESCRIPTION
- No longer need `as.data.frame()` twice
- Disable skips
- Modernize sql_union()
- Breadcrumbs
- Align paths
