### PR TITLE
feat: Assign result in `send_query_stale_warning` to stabilize test

### DIFF
--- a/R/spec-result-send-query.R
+++ b/R/spec-result-send-query.R
@@ -74,7 +74,7 @@ spec_result_send_query <- list(
     #' when the connection is closed.
     con <- connect(ctx)
     on.exit(dbDisconnect(con))
-    expect_warning(dbSendQuery(con, trivial_query()), NA)
+    expect_warning(res<-dbSendQuery(con, trivial_query()), NA)
 
     expect_warning({
       dbDisconnect(con)


### PR DESCRIPTION
Hi @krlmlr 

Seeing ( intermittent ) [failures](https://github.com/r-dbi/odbc/actions/runs/11075855266/attempts/4) [in](https://github.com/r-dbi/odbc/actions/runs/11075855266/attempts/3) [odbc](https://github.com/r-dbi/odbc/actions/runs/11075855266/attempts/2) [pipelines](https://github.com/r-dbi/odbc/actions/runs/11075855266/attempts/1), that I am having trouble replicating on my boxes.  They are windows only + sql server specific, though I think that may be a red herring.

I **think** the failures may be caused by the return value of `dbSendQuery` in the test below not being assigned to a named variable.  I wonder if because of that, it's possible for the "rvalue" result object to be garbage collected before the `dbDisconnect` call below.  If that were to happen, there would be no warning emitted when the disconnect call goes through, as the result has already been destroyed/released.

I listed four failures pipeline above.  In between failure three and four I ran an identical job using this branch of `DBItest` and the [pipeline passed](https://github.com/r-dbi/odbc/actions/runs/11083599224/job/30797995214).  Somewhat unscientific, I know, and without a windows box to test on this is mostly guesswork.

Strike against this theory is that I can't think of any recent changes that would have caused this issue  to suddenly flare up.  Then again, I always struggle with issues related to garbage collection.

Cheers.