### PR TITLE
chore: Add build-time dependency vctrs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,8 @@ Suggests:
     lintr,
     pkgload,
     rmarkdown,
-    RSQLite
+    RSQLite,
+    vctrs
 VignetteBuilder: 
     knitr
 Config/Needs/website: 


### PR DESCRIPTION
Closes #394 

The R ecosystem lacks a good way to specify `R CMD build`-time required dependencies, IME `Suggests` is not a bad place.