### PR TITLE
feat: Clarify warning message for lack of `skip =` hit among `spec_all`

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -111,7 +111,7 @@ get_skip_names <- function(skip) {
   skip_flags_all <- map(paste0("(?:^(?:", skip, ")(?:|_[0-9]+)$)"), grepl, names_all, perl = TRUE)
   skip_used <- map_lgl(skip_flags_all, any)
   if (!all(skip_used)) {
-    warning("Unused skip expressions: ", paste(skip[!skip_used], collapse = ", "),
+    warning("These skip expressions did not match any test names: ", toString(skip[!skip_used]),
       call. = FALSE
     )
   }


### PR DESCRIPTION
Came across the old warning in a test log without enough context and wasn't sure what to make of it.

I think this will make it clearer what exactly's gone wrong.