### PR TITLE
docs: Improve wording of `test_all(skip = )` description

### DIFF
--- a/R/test-all.R
+++ b/R/test-all.R
@@ -13,10 +13,10 @@
 #'
 #' @param skip `[character()]`\cr A vector of regular expressions to match
 #'   against test names; skip test if matching any.
-#'   The regular expressions are matched against the entire test name
-#'   minus a possible suffix `_N` where `N` is a number.
+#'   To improve precision, the regular expressions are matched against the
+#'   entire test name minus a possible suffix `_N` where `N` is a number.
 #'   For example, `skip = "exists_table"` will skip both
-#'   `"exists_table_1"` and `"exists_table_2"`.
+#'   `"exists_table_1"` and `"exists_table_2"`, but not `"there_exists_table"`.
 #' @param run_only `[character()]`\cr A vector of regular expressions to match
 #'   against test names; run only these tests.
 #'   The regular expressions are matched against the entire test name.

--- a/man/test_all.Rd
+++ b/man/test_all.Rd
@@ -15,10 +15,10 @@ test_some(test, ctx = get_default_context())
 \arguments{
 \item{skip}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; skip test if matching any.
-The regular expressions are matched against the entire test name
-minus a possible suffix \verb{_N} where \code{N} is a number.
+To improve precision, the regular expressions are matched against the
+entire test name minus a possible suffix \verb{_N} where \code{N} is a number.
 For example, \code{skip = "exists_table"} will skip both
-\code{"exists_table_1"} and \code{"exists_table_2"}.}
+\code{"exists_table_1"} and \code{"exists_table_2"}, but not \code{"there_exists_table"}.}
 
 \item{run_only}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; run only these tests.

--- a/man/test_arrow.Rd
+++ b/man/test_arrow.Rd
@@ -9,10 +9,10 @@ test_arrow(skip = NULL, run_only = NULL, ctx = get_default_context())
 \arguments{
 \item{skip}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; skip test if matching any.
-The regular expressions are matched against the entire test name
-minus a possible suffix \verb{_N} where \code{N} is a number.
+To improve precision, the regular expressions are matched against the
+entire test name minus a possible suffix \verb{_N} where \code{N} is a number.
 For example, \code{skip = "exists_table"} will skip both
-\code{"exists_table_1"} and \code{"exists_table_2"}.}
+\code{"exists_table_1"} and \code{"exists_table_2"}, but not \code{"there_exists_table"}.}
 
 \item{run_only}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; run only these tests.

--- a/man/test_compliance.Rd
+++ b/man/test_compliance.Rd
@@ -9,10 +9,10 @@ test_compliance(skip = NULL, run_only = NULL, ctx = get_default_context())
 \arguments{
 \item{skip}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; skip test if matching any.
-The regular expressions are matched against the entire test name
-minus a possible suffix \verb{_N} where \code{N} is a number.
+To improve precision, the regular expressions are matched against the
+entire test name minus a possible suffix \verb{_N} where \code{N} is a number.
 For example, \code{skip = "exists_table"} will skip both
-\code{"exists_table_1"} and \code{"exists_table_2"}.}
+\code{"exists_table_1"} and \code{"exists_table_2"}, but not \code{"there_exists_table"}.}
 
 \item{run_only}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; run only these tests.

--- a/man/test_connection.Rd
+++ b/man/test_connection.Rd
@@ -9,10 +9,10 @@ test_connection(skip = NULL, run_only = NULL, ctx = get_default_context())
 \arguments{
 \item{skip}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; skip test if matching any.
-The regular expressions are matched against the entire test name
-minus a possible suffix \verb{_N} where \code{N} is a number.
+To improve precision, the regular expressions are matched against the
+entire test name minus a possible suffix \verb{_N} where \code{N} is a number.
 For example, \code{skip = "exists_table"} will skip both
-\code{"exists_table_1"} and \code{"exists_table_2"}.}
+\code{"exists_table_1"} and \code{"exists_table_2"}, but not \code{"there_exists_table"}.}
 
 \item{run_only}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; run only these tests.

--- a/man/test_driver.Rd
+++ b/man/test_driver.Rd
@@ -9,10 +9,10 @@ test_driver(skip = NULL, run_only = NULL, ctx = get_default_context())
 \arguments{
 \item{skip}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; skip test if matching any.
-The regular expressions are matched against the entire test name
-minus a possible suffix \verb{_N} where \code{N} is a number.
+To improve precision, the regular expressions are matched against the
+entire test name minus a possible suffix \verb{_N} where \code{N} is a number.
 For example, \code{skip = "exists_table"} will skip both
-\code{"exists_table_1"} and \code{"exists_table_2"}.}
+\code{"exists_table_1"} and \code{"exists_table_2"}, but not \code{"there_exists_table"}.}
 
 \item{run_only}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; run only these tests.

--- a/man/test_getting_started.Rd
+++ b/man/test_getting_started.Rd
@@ -9,10 +9,10 @@ test_getting_started(skip = NULL, run_only = NULL, ctx = get_default_context())
 \arguments{
 \item{skip}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; skip test if matching any.
-The regular expressions are matched against the entire test name
-minus a possible suffix \verb{_N} where \code{N} is a number.
+To improve precision, the regular expressions are matched against the
+entire test name minus a possible suffix \verb{_N} where \code{N} is a number.
 For example, \code{skip = "exists_table"} will skip both
-\code{"exists_table_1"} and \code{"exists_table_2"}.}
+\code{"exists_table_1"} and \code{"exists_table_2"}, but not \code{"there_exists_table"}.}
 
 \item{run_only}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; run only these tests.

--- a/man/test_meta.Rd
+++ b/man/test_meta.Rd
@@ -9,10 +9,10 @@ test_meta(skip = NULL, run_only = NULL, ctx = get_default_context())
 \arguments{
 \item{skip}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; skip test if matching any.
-The regular expressions are matched against the entire test name
-minus a possible suffix \verb{_N} where \code{N} is a number.
+To improve precision, the regular expressions are matched against the
+entire test name minus a possible suffix \verb{_N} where \code{N} is a number.
 For example, \code{skip = "exists_table"} will skip both
-\code{"exists_table_1"} and \code{"exists_table_2"}.}
+\code{"exists_table_1"} and \code{"exists_table_2"}, but not \code{"there_exists_table"}.}
 
 \item{run_only}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; run only these tests.

--- a/man/test_result.Rd
+++ b/man/test_result.Rd
@@ -9,10 +9,10 @@ test_result(skip = NULL, run_only = NULL, ctx = get_default_context())
 \arguments{
 \item{skip}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; skip test if matching any.
-The regular expressions are matched against the entire test name
-minus a possible suffix \verb{_N} where \code{N} is a number.
+To improve precision, the regular expressions are matched against the
+entire test name minus a possible suffix \verb{_N} where \code{N} is a number.
 For example, \code{skip = "exists_table"} will skip both
-\code{"exists_table_1"} and \code{"exists_table_2"}.}
+\code{"exists_table_1"} and \code{"exists_table_2"}, but not \code{"there_exists_table"}.}
 
 \item{run_only}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; run only these tests.

--- a/man/test_sql.Rd
+++ b/man/test_sql.Rd
@@ -9,10 +9,10 @@ test_sql(skip = NULL, run_only = NULL, ctx = get_default_context())
 \arguments{
 \item{skip}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; skip test if matching any.
-The regular expressions are matched against the entire test name
-minus a possible suffix \verb{_N} where \code{N} is a number.
+To improve precision, the regular expressions are matched against the
+entire test name minus a possible suffix \verb{_N} where \code{N} is a number.
 For example, \code{skip = "exists_table"} will skip both
-\code{"exists_table_1"} and \code{"exists_table_2"}.}
+\code{"exists_table_1"} and \code{"exists_table_2"}, but not \code{"there_exists_table"}.}
 
 \item{run_only}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; run only these tests.

--- a/man/test_stress.Rd
+++ b/man/test_stress.Rd
@@ -9,10 +9,10 @@ test_stress(skip = NULL, ctx = get_default_context())
 \arguments{
 \item{skip}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; skip test if matching any.
-The regular expressions are matched against the entire test name
-minus a possible suffix \verb{_N} where \code{N} is a number.
+To improve precision, the regular expressions are matched against the
+entire test name minus a possible suffix \verb{_N} where \code{N} is a number.
 For example, \code{skip = "exists_table"} will skip both
-\code{"exists_table_1"} and \code{"exists_table_2"}.}
+\code{"exists_table_1"} and \code{"exists_table_2"}, but not \code{"there_exists_table"}.}
 
 \item{ctx}{\verb{[DBItest_context]}\cr A test context as created by
 \code{\link[=make_context]{make_context()}}.}

--- a/man/test_transaction.Rd
+++ b/man/test_transaction.Rd
@@ -9,10 +9,10 @@ test_transaction(skip = NULL, run_only = NULL, ctx = get_default_context())
 \arguments{
 \item{skip}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; skip test if matching any.
-The regular expressions are matched against the entire test name
-minus a possible suffix \verb{_N} where \code{N} is a number.
+To improve precision, the regular expressions are matched against the
+entire test name minus a possible suffix \verb{_N} where \code{N} is a number.
 For example, \code{skip = "exists_table"} will skip both
-\code{"exists_table_1"} and \code{"exists_table_2"}.}
+\code{"exists_table_1"} and \code{"exists_table_2"}, but not \code{"there_exists_table"}.}
 
 \item{run_only}{\verb{[character()]}\cr A vector of regular expressions to match
 against test names; run only these tests.


### PR DESCRIPTION
Closes #397 