### PR TITLE
Cast to data.frame to ignore other data.frame-extended classes in get_query_good_after_bad_n

### DIFF
--- a/R/spec-result-fetch.R
+++ b/R/spec-result-fetch.R
@@ -18,7 +18,7 @@ spec_result_fetch <- list(
     query <- trivial_query()
     res <- local_result(dbSendQuery(con, query))
     rows <- check_df(dbFetch(res))
-    expect_equal(rows, data.frame(a = 1.5))
+    expect_equal(as.data.frame(rows), data.frame(a = 1.5))
   },
 
   fetch_one_row = function(con) {


### PR DESCRIPTION
Related: #400.

From `test_result(run_only = 'get_query_good_after_bad_n')` I am getting:

```
── Failure: DBItest: Result: get_query_good_after_bad_n ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
`rows` (`actual`) not equal to data.frame(a = 1.5) (`expected`).

`class(actual)`:   "tbl_df" "tbl" "data.frame"
`class(expected)`:                "data.frame"
Backtrace:
    ▆
 1. └─DBItest:::spec_result$get_query_good_after_bad_n(con = global_con)
 2.   └─testthat::expect_equal(rows, data.frame(a = 1.5)) at rbuild/R/spec-result-get-query.R:83:5

Error:
! Test failed
Run `rlang::last_trace()` to see where the error occurred.
```

Another option is to weaken the expected value side:

```r
expect_length(rows, 1L)
expect_identical(rows[["a"]], 1.5)
```

(`check_df()` just above already handles the `data.frame` check)