### PR TITLE
feat: Test object returned by `dbUnquoteIdentifier()` is of class `Id`

### DIFF
--- a/R/spec-sql-unquote-identifier.R
+++ b/R/spec-sql-unquote-identifier.R
@@ -22,10 +22,12 @@ spec_sql_unquote_identifier <- list(
     simple_in <- dbQuoteIdentifier(con, "simple")
     simple_out <- dbUnquoteIdentifier(con, simple_in)
     expect_equal(length(simple_out), 1L)
+    expect_s4_class(simple_out[[1L]], "Id")
 
     letters_in <- dbQuoteIdentifier(con, letters)
     letters_out <- dbUnquoteIdentifier(con, letters_in)
     expect_equal(length(letters_out), length(letters_in))
+    for (obj in letters_out) expect_s4_class(obj, "Id")
 
     #' For an empty vector, this function returns a length-0 object.
     empty <- character()
@@ -44,6 +46,7 @@ spec_sql_unquote_identifier <- list(
     named_in <- dbQuoteIdentifier(con, stats::setNames(LETTERS[1:3], letters[1:3]))
     named_out <- dbUnquoteIdentifier(con, named_in)
     expect_equal(names(named_out), letters[1:3])
+    for (obj in named_out) expect_s4_class(obj, "Id")
 
     #' If `x` is a value returned by `dbUnquoteIdentifier()`,
     #' calling `dbUnquoteIdentifier(..., dbQuoteIdentifier(..., x))`


### PR DESCRIPTION
Closes #403

I haven't dived in to how unit testing is done for {DBItest}, any advice would be helpful. I searched for "quote" in the testthat/ folder with no hits, so I didn't see an easy way to shoehorn my way in.

I did notice this floating comment, it might be referring to the code in question?

https://github.com/r-dbi/DBItest/blob/f19fb4d81cc9203b328bcc475e873480e3bd8710/R/spec-sql-unquote-identifier.R#L57-L58

But if so, maybe it's outdated? Since as noted, `dbUnquoteIdentifier()` _is_ documented to return `Id`.

This was added to {DBItest} (Mar. 2018) not long after `[Id]` was documented as the return for `dbUnquoteIdentifier()` (Feb. 2018):

https://github.com/r-dbi/DBI/commit/8f2a2e9eb341a00d48467290a7587602ccd01642

e291f73252cd5b7de91fe5cd3cf35c56691a4d70