### PR TITLE
feat: Improve failure mode of missing method test

### DIFF
--- a/R/spec-compliance-methods.R
+++ b/R/spec-compliance-methods.R
@@ -25,14 +25,12 @@ spec_compliance_methods <- list(
 
     pkg <- package_name(ctx)
 
-    where <- asNamespace(pkg)
-
     sapply(names(key_methods), function(name) {
       dbi_class <- paste0("DBI", name)
 
       classes <- Filter(function(class) {
         extends(class, dbi_class) && getClass(class)@virtual == FALSE
-      }, getClasses(where))
+      }, getClasses(asNamespace(pkg)))
 
       expect_gte(length(classes), 1)
 
@@ -42,7 +40,7 @@ spec_compliance_methods <- list(
       #' of these base classes
       #' that are defined but not implemented by DBI.
       mapply(function(method, args) {
-        expect_has_class_method(method, class, args, where)
+        expect_has_class_method(method, class, args, pkg)
       }, names(key_methods[[name]]), key_methods[[name]])
     })
     #
@@ -98,7 +96,7 @@ spec_compliance_methods <- list(
 expect_has_class_method <- function(name, class, args, driver_package) {
   full_args <- c(class, args)
   eval(bquote(
-    expect_true(hasMethod(.(name), .(full_args), driver_package))
+    expect_true(hasMethod(.(name), signature = .(full_args), asNamespace(.(driver_package))))
   ))
 }
 


### PR DESCRIPTION
Currently this can fail like:

```
hasMethod("dbDisconnect", "MyDBIConnection", driver_package) is not TRUE

`actual`:   FALSE
`expected`: TRUE 
Backtrace:
     x
  1. \-DBItest:::spec_compliance$compliance(ctx = ctx)
  2.   \-base::sapply(...) at [rbuild/R/spec-compliance-methods.R:30]
  3.     \-base::lapply(X = X, FUN = FUN, ...)
  4.       \-DBItest (local) FUN(X[[i]], ...)
  5.         \-base::mapply(...) at [rbuild/R/spec-compliance-methods.R:44]
  6.           \-DBItest (local) `<fn>`(dots[[1L]][[1L]], dots[[2L]][[1L]])
  7.             \-DBItest:::expect_has_class_method(method, class, args, where) at [rbuild/R/spec-compliance-methods.R:45]
  8.               +-base::eval(...) at [rbuild/R/spec-compliance-methods.R:100]
  9.               | \-base::eval(...)
 10.               \-testthat::expect_true(...)
```

I'm unsure why this is failing, but seeing `driver_package` makes it a bit harder -- with this change the error should look like this instead:

```
hasMethod("dbDisconnect", signature = "MyDBIConnection", asNamespace("<searched package>")) is not TRUE
```

That will give something more actionable for my debugging.