### PR TITLE
feat: New `tweaks(create_table_empty = )` tweak

### DIFF
--- a/R/spec-meta-get-row-count.R
+++ b/R/spec-meta-get-row-count.R
@@ -57,8 +57,8 @@ spec_meta_get_row_count <- list(
     expect_equal(rc, 0L)
   },
   #
-  row_count_statement = function(con, table_name) {
-    query <- paste0("CREATE TABLE ", table_name, " (a integer)")
+  row_count_statement = function(ctx, con, table_name) {
+    query <- ctx$tweaks$create_table_empty(table_name)
     #' For data manipulation statements issued with
     #' [dbSendStatement()],
     res <- local_result(dbSendStatement(con, query))

--- a/R/spec-meta-get-rows-affected.R
+++ b/R/spec-meta-get-rows-affected.R
@@ -54,11 +54,9 @@ spec_meta_get_rows_affected <- list(
     #' `NA` values are not allowed.
   },
   #'
-  get_rows_affected_error = function(con, table_name) {
+  get_rows_affected_error = function(ctx, con, table_name) {
     #' @section Failure modes:
-    query <- paste0(
-      "CREATE TABLE ", dbQuoteIdentifier(con, table_name), " (a integer)"
-    )
+    query <- ctx$tweaks$create_table_empty(table_name)
     res <- dbSendStatement(con, query)
     dbClearResult(res)
     #' Attempting to get the rows affected for a result set cleared with

--- a/R/spec-meta-get-statement.R
+++ b/R/spec-meta-get-statement.R
@@ -20,8 +20,8 @@ spec_meta_get_statement <- list(
     expect_identical(s, query)
   },
   #
-  get_statement_statement = function(con, table_name) {
-    query <- paste0("CREATE TABLE ", table_name, " (a integer)")
+  get_statement_statement = function(ctx, con, table_name) {
+    query <- ctx$tweaks$create_table_empty(table_name)
     #' [dbSendStatement()].
     res <- local_result(dbSendStatement(con, query))
     s <- dbGetStatement(res)

--- a/R/spec-meta-has-completed.R
+++ b/R/spec-meta-has-completed.R
@@ -21,9 +21,10 @@ spec_meta_has_completed <- list(
     expect_true(expect_visible(dbHasCompleted(res)))
   },
   #
-  has_completed_statement = function(con, table_name) {
+  has_completed_statement = function(ctx, con, table_name) {
     #' For a query initiated by [dbSendStatement()],
-    res <- local_result(dbSendStatement(con, paste0("CREATE TABLE ", table_name, " (a integer)")))
+    query <- ctx$tweaks$create_table_empty(table_name)
+    res <- local_result(dbSendStatement(con, query))
     #' `dbHasCompleted()` always returns `TRUE`.
     expect_true(expect_visible(dbHasCompleted(res)))
   },

--- a/R/spec-meta-is-valid.R
+++ b/R/spec-meta-is-valid.R
@@ -43,8 +43,8 @@ spec_meta_is_valid <- list(
     expect_false(dbIsValid(res))
   },
   #
-  is_valid_result_statement = function(con, table_name) {
-    query <- paste0("CREATE TABLE ", table_name, " (a ", dbDataType(con, 1L), ")")
+  is_valid_result_statement = function(ctx, con, table_name) {
+    query <- ctx$tweaks$create_table_empty(table_name)
     res <- dbSendStatement(con, query)
     on.exit(dbClearResult(res))
     #' A [DBIResult-class] object is also valid after a call to [dbSendStatement()],

--- a/R/spec-result-fetch.R
+++ b/R/spec-result-fetch.R
@@ -84,12 +84,12 @@ spec_result_fetch <- list(
     expect_equal(rows, data.frame(a = 1.5))
   },
 
-  fetch_no_return_value = function(con, table_name) {
+  fetch_no_return_value = function(ctx, con, table_name) {
     #'
     #' Calling `dbFetch()` on a result set from a data manipulation query
     #' created by [dbSendStatement()] can
     #' be fetched and return an empty data frame, with a warning.
-    query <- paste0("CREATE TABLE ", table_name, " (a integer)")
+    query <- ctx$tweaks$create_table_empty(table_name)
 
     res <- local_result(dbSendStatement(con, query))
     expect_warning(rows <- check_df(dbFetch(res)))

--- a/R/tweaks.R
+++ b/R/tweaks.R
@@ -115,6 +115,11 @@
     #'   from an SQL expression.
     "create_table_as" = function(table_name, query) paste0("CREATE TABLE ", table_name, " AS ", query),
 
+    #' @param create_table_empty `[function(character(1))]`\cr
+    #'   A function that creates an SQL expression for creating an empty table
+    #'   with a single integer column named 'a'.
+    "create_table_empty" = function(table_name) paste0("CREATE TABLE ", table_name, " (a integer)")
+
     #' @param dbitest_version `[character(1)]`\cr
     #'   Compatible DBItest version, default: "1.7.1".
     "dbitest_version" = "1.7.1",

--- a/R/tweaks.R
+++ b/R/tweaks.R
@@ -118,7 +118,7 @@
     #' @param create_table_empty `[function(character(1))]`\cr
     #'   A function that creates an SQL expression for creating an empty table
     #'   with a single integer column named 'a'.
-    "create_table_empty" = function(table_name) paste0("CREATE TABLE ", table_name, " (a integer)")
+    "create_table_empty" = function(table_name) paste0("CREATE TABLE ", table_name, " (a integer)"),
 
     #' @param dbitest_version `[character(1)]`\cr
     #'   Compatible DBItest version, default: "1.7.1".

--- a/man/tweaks.Rd
+++ b/man/tweaks.Rd
@@ -113,6 +113,10 @@ value is \code{NULL}.}
 A function that creates an SQL expression for creating a table
 from an SQL expression.}
 
+\item{create_table_empty}{\verb{[function(character(1))]}\cr
+A function that creates an SQL expression for creating an empty table
+with a single integer column named 'a'.}
+
 \item{dbitest_version}{\verb{[character(1)]}\cr
 Compatible DBItest version, default: "1.7.1".}
 }

--- a/man/tweaks.Rd
+++ b/man/tweaks.Rd
@@ -27,6 +27,8 @@ tweaks(
   is_null_check = function(x) paste0("(", x, " IS NULL)"),
   create_table_as = function(table_name, query) paste0("CREATE TABLE ", table_name,
     " AS ", query),
+  create_table_empty = function(table_name) paste0("CREATE TABLE ", table_name,
+    " (a integer)"),
   dbitest_version = "1.7.1"
 )
 }


### PR DESCRIPTION
Closes #406

Initial implementation, needs some clean-up.

Want to check that this gets the rough idea right.

We'd be able to make this even more robust by passing in `con`, then we could include this last case:

https://github.com/r-dbi/DBItest/blob/f19fb4d81cc9203b328bcc475e873480e3bd8710/R/spec-result-create-table-with-data-type.R#L15

It would also keep better fidelity to these other cases:

https://github.com/r-dbi/DBItest/blob/f19fb4d81cc9203b328bcc475e873480e3bd8710/R/spec-meta-get-rows-affected.R#L60
https://github.com/r-dbi/DBItest/blob/f19fb4d81cc9203b328bcc475e873480e3bd8710/R/spec-meta-is-valid.R#L47

But I didn't see any other tweaks using `con` so I shied away from that for now.

(this is a re-file of #407 on a proper branch for simplicity)