### PR TITLE
feat: Add an extra test for sanity in spec-sql-write-table

### DIFF
--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -88,6 +88,7 @@ spec_sql_write_table <- list(
     expect_error(dbWriteTable(con, table_name, test_in, field.types = c("INTEGER")))
 
     #' incompatible columns)
+    expect_false(dbExistsTable(con, table_name))
     dbWriteTable(con, table_name, test_in)
     expect_error(dbWriteTable(con, table_name, data.frame(b = 2L, c = 3L), append = TRUE))
 


### PR DESCRIPTION
A backend which fails any of the earlier tests here, will likely have succeeded in populating `table_name`, thus creating a  red herring whereby we get an error from `dbWriteTable()` that might be hard to reason about in isolation.

Having this extra `dbExistsTable()` check should help to steer the ship when debugging.