### PR TITLE
feat: Use `trivial_query()` by default in `create_table_as()`

### DIFF
--- a/R/spec-result-clear-result.R
+++ b/R/spec-result-clear-result.R
@@ -20,7 +20,7 @@ spec_result_clear_result <- list(
 
   clear_result_return_statement = function(ctx, con, table_name) {
     #' `dbSendStatement()`,
-    res <- dbSendStatement(con, ctx$tweaks$create_table_as(table_name, "SELECT 1"))
+    res <- dbSendStatement(con, ctx$tweaks$create_table_as(table_name))
     expect_invisible_true(dbClearResult(res))
   },
 
@@ -29,7 +29,7 @@ spec_result_clear_result <- list(
     skip_if_not_dbitest(ctx, "1.7.99.3")
 
     #' or `dbSendQueryArrow()`,
-    res <- dbSendQueryArrow(con, ctx$tweaks$create_table_as(table_name, "SELECT 1"))
+    res <- dbSendQueryArrow(con, ctx$tweaks$create_table_as(table_name))
     expect_invisible_true(dbClearResult(res))
   },
 
@@ -45,7 +45,7 @@ spec_result_clear_result <- list(
 
   cannot_clear_result_twice_statement = function(ctx, con, table_name) {
     #' `dbSendStatement()`,
-    res <- dbSendStatement(con, ctx$tweaks$create_table_as(table_name, "SELECT 1"))
+    res <- dbSendStatement(con, ctx$tweaks$create_table_as(table_name))
     dbClearResult(res)
     expect_warning(expect_invisible_true(dbClearResult(res)))
   },
@@ -55,7 +55,7 @@ spec_result_clear_result <- list(
     skip_if_not_dbitest(ctx, "1.7.99.4")
 
     #' and `dbSendQueryArrow()`,
-    res <- dbSendQueryArrow(con, ctx$tweaks$create_table_as(table_name, "SELECT 1"))
+    res <- dbSendQueryArrow(con, ctx$tweaks$create_table_as(table_name))
     dbClearResult(res)
     expect_warning(expect_invisible_true(dbClearResult(res)))
   },

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -84,7 +84,7 @@ spec_result_send_statement <- list(
     local_remove_test_table(con, other_table_name)
     #' issuing a second query invalidates an already open result set
     #' and raises a warning.
-    query <- ctx$tweaks$create_table_as(other_table_name, "SELECT 1 AS a")
+    query <- ctx$tweaks$create_table_as(other_table_name)
     expect_warning(res2 <- dbSendStatement(con, query))
     expect_false(dbIsValid(res1))
     #' The newly opened result set is valid

--- a/R/spec-result.R
+++ b/R/spec-result.R
@@ -31,7 +31,7 @@ sql_union <- function(..., .order_by = NULL, .ctx) {
 }
 
 trivial_statement <- function(ctx, table_name) {
-  ctx$tweaks$create_table_as(table_name, trivial_query())
+  ctx$tweaks$create_table_as(table_name)
 }
 
 trivial_query <- function(n = 1L, column = "a", .order_by = NULL, .ctx = NULL) {

--- a/R/tweaks.R
+++ b/R/tweaks.R
@@ -113,7 +113,7 @@
     #' @param create_table_as `[function(character(1), character(1))]`\cr
     #'   A function that creates an SQL expression for creating a table
     #'   from an SQL expression.
-    "create_table_as" = function(table_name, query) paste0("CREATE TABLE ", table_name, " AS ", query),
+    "create_table_as" = function(table_name, query = trivial_query()) paste0("CREATE TABLE ", table_name, " AS ", query),
 
     #' @param create_table_empty `[function(character(1))]`\cr
     #'   A function that creates an SQL expression for creating an empty table

--- a/man/tweaks.Rd
+++ b/man/tweaks.Rd
@@ -25,8 +25,8 @@ tweaks(
   list_temporary_tables = TRUE,
   allow_na_rows_affected = FALSE,
   is_null_check = function(x) paste0("(", x, " IS NULL)"),
-  create_table_as = function(table_name, query) paste0("CREATE TABLE ", table_name,
-    " AS ", query),
+  create_table_as = function(table_name, query = trivial_query()) paste0(
+    "CREATE TABLE ", table_name, " AS ", query),
   create_table_empty = function(table_name) paste0("CREATE TABLE ", table_name,
     " (a integer)"),
   dbitest_version = "1.7.1"


### PR DESCRIPTION
Closes #410 

I think this is a good solution. We could also explicitly use `trivial_query()` consistently, but this seems easier to remember going forward to prevent regression.