### PR TITLE
fix: compare integer64 logical tweaks by value

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Imports:
     utils,
     withr
 Suggests: 
+    bit64,
     clipr,
     constructive,
     debugme,

--- a/R/spec-arrow-append-table-arrow.R
+++ b/R/spec-arrow-append-table-arrow.R
@@ -36,8 +36,8 @@ spec_arrow_append_table_arrow <- list(
     #' or the new data in `values` is not a data frame or has different column names,
     #' an error is raised; the remote table remains unchanged.
     test_in <- trivial_df()
-    dbCreateTableArrow(con, table_name, test_in %>% stream_frame())
-    expect_error(dbAppendTableArrow(con, table_name, test_in %>% stream_frame() %>% unclass()))
+    dbCreateTableArrow(con, table_name, stream_frame(test_in))
+    expect_error(dbAppendTableArrow(con, table_name, unclass(stream_frame(test_in))))
 
     test_out <- check_df(dbReadTable(con, table_name))
     expect_equal_arrow(test_out, test_in[0, , drop = FALSE])
@@ -45,8 +45,8 @@ spec_arrow_append_table_arrow <- list(
 
   arrow_append_table_arrow_append_incompatible = function(con, table_name) {
     test_in <- trivial_df()
-    dbCreateTableArrow(con, table_name, test_in %>% stream_frame())
-    dbAppendTableArrow(con, table_name, test_in %>% stream_frame())
+    dbCreateTableArrow(con, table_name, stream_frame(test_in))
+    dbAppendTableArrow(con, table_name, stream_frame(test_in))
     expect_error(dbAppendTableArrow(con, table_name, stream_frame(b = 2L)))
 
     test_out <- check_df(dbReadTable(con, table_name))
@@ -492,8 +492,8 @@ spec_arrow_append_table_arrow <- list(
 
       local_remove_test_table(con, table_name)
       #' - If an unquoted table name as string: `dbAppendTableArrow()` will do the quoting,
-      dbCreateTableArrow(con, table_name, test_in %>% stream_frame())
-      dbAppendTableArrow(con, table_name, test_in %>% stream_frame())
+      dbCreateTableArrow(con, table_name, stream_frame(test_in))
+      dbAppendTableArrow(con, table_name, stream_frame(test_in))
       test_out <- check_df(dbReadTable(con, dbQuoteIdentifier(con, table_name)))
       expect_equal_arrow(test_out, test_in)
       #'   perhaps by calling `dbQuoteIdentifier(conn, x = name)`
@@ -515,8 +515,8 @@ spec_arrow_append_table_arrow <- list(
       test_in <- trivial_df()
 
       local_remove_test_table(con, table_name)
-      dbCreateTableArrow(con, dbQuoteIdentifier(con, table_name), test_in %>% stream_frame())
-      dbAppendTableArrow(con, dbQuoteIdentifier(con, table_name), test_in %>% stream_frame())
+      dbCreateTableArrow(con, dbQuoteIdentifier(con, table_name), stream_frame(test_in))
+      dbAppendTableArrow(con, dbQuoteIdentifier(con, table_name), stream_frame(test_in))
       test_out <- check_df(dbReadTable(con, table_name))
       expect_equal_arrow(test_out, test_in)
     }
@@ -527,8 +527,8 @@ spec_arrow_append_table_arrow <- list(
     #' @section Specification:
     #' The `value` argument must be a data frame
     test_in <- trivial_df()
-    dbCreateTableArrow(con, table_name, test_in %>% stream_frame())
-    dbAppendTableArrow(con, table_name, test_in %>% stream_frame())
+    dbCreateTableArrow(con, table_name, stream_frame(test_in))
+    dbAppendTableArrow(con, table_name, stream_frame(test_in))
 
     test_out <- check_df(dbReadTable(con, table_name))
     expect_equal_arrow(test_out, test_in)
@@ -537,8 +537,8 @@ spec_arrow_append_table_arrow <- list(
   arrow_append_table_arrow_value_subset = function(ctx, con, table_name) {
     #' with a subset of the columns of the existing table.
     test_in <- trivial_df(3, letters[1:3])
-    dbCreateTableArrow(con, table_name, test_in %>% stream_frame())
-    dbAppendTableArrow(con, table_name, test_in %>% stream_frame(.select = 2))
+    dbCreateTableArrow(con, table_name, stream_frame(test_in))
+    dbAppendTableArrow(con, table_name, stream_frame(test_in, .select = 2))
 
     test_out <- check_df(dbReadTable(con, table_name))
 
@@ -549,8 +549,8 @@ spec_arrow_append_table_arrow <- list(
   arrow_append_table_arrow_value_shuffle = function(ctx, con, table_name) {
     #' The order of the columns does not matter.
     test_in <- trivial_df(3, letters[1:3])
-    dbCreateTableArrow(con, table_name, test_in %>% stream_frame())
-    dbAppendTableArrow(con, table_name, test_in %>% stream_frame(.select = c(2, 3, 1)))
+    dbCreateTableArrow(con, table_name, stream_frame(test_in))
+    dbAppendTableArrow(con, table_name, stream_frame(test_in, .select = c(2, 3, 1)))
 
     test_out <- check_df(dbReadTable(con, table_name))
     expect_equal_arrow(test_out, test_in)
@@ -559,8 +559,8 @@ spec_arrow_append_table_arrow <- list(
   #
   arrow_append_table_arrow_value_shuffle_subset = function(ctx, con, table_name) {
     test_in <- trivial_df(4, letters[1:4])
-    dbCreateTableArrow(con, table_name, test_in %>% stream_frame())
-    dbAppendTableArrow(con, table_name, test_in %>% stream_frame(.select = c(4, 1, 3)))
+    dbCreateTableArrow(con, table_name, stream_frame(test_in))
+    dbAppendTableArrow(con, table_name, stream_frame(test_in, .select = c(4, 1, 3)))
 
     test_out <- check_df(dbReadTable(con, table_name))
     test_in[2] <- NA_real_

--- a/R/spec-arrow-create-table-arrow.R
+++ b/R/spec-arrow-create-table-arrow.R
@@ -23,8 +23,8 @@ spec_arrow_create_table_arrow <- list(
     #' If the table exists, an error is raised; the remote table remains unchanged.
     test_in <- trivial_df()
 
-    dbCreateTableArrow(con, table_name, test_in %>% stream_frame())
-    dbAppendTableArrow(con, table_name, test_in %>% stream_frame())
+    dbCreateTableArrow(con, table_name, stream_frame(test_in))
+    dbAppendTableArrow(con, table_name, stream_frame(test_in))
     expect_error(dbCreateTableArrow(con, table_name, stream_frame(b = 1L)))
 
     test_out <- check_df(dbReadTable(con, table_name))
@@ -92,7 +92,7 @@ spec_arrow_create_table_arrow <- list(
 
       local_remove_test_table(con, table_name)
       #' - If an unquoted table name as string: `dbCreateTableArrow()` will do the quoting,
-      dbCreateTableArrow(con, table_name, test_in %>% stream_frame())
+      dbCreateTableArrow(con, table_name, stream_frame(test_in))
       test_out <- check_df(dbReadTable(con, dbQuoteIdentifier(con, table_name)))
       expect_equal_df(test_out, test_in[0, , drop = FALSE])
       #'   perhaps by calling `dbQuoteIdentifier(conn, x = name)`
@@ -113,7 +113,7 @@ spec_arrow_create_table_arrow <- list(
       test_in <- trivial_df()
 
       local_remove_test_table(con, table_name)
-      dbCreateTableArrow(con, dbQuoteIdentifier(con, table_name), test_in %>% stream_frame())
+      dbCreateTableArrow(con, dbQuoteIdentifier(con, table_name), stream_frame(test_in))
       test_out <- check_df(dbReadTable(con, table_name))
       expect_equal_df(test_out, test_in[0, , drop = FALSE])
     }

--- a/R/spec-arrow-write-table-arrow.R
+++ b/R/spec-arrow-write-table-arrow.R
@@ -23,7 +23,7 @@ spec_arrow_write_table_arrow <- list(
     #' @section Failure modes:
     #' If the table exists, and both `append` and `overwrite` arguments are unset,
     test_in <- data.frame(a = 1L)
-    dbWriteTableArrow(con, table_name, test_in %>% stream_frame())
+    dbWriteTableArrow(con, table_name, stream_frame(test_in))
     expect_error(dbWriteTableArrow(con, table_name, stream_frame(a = 2L)))
 
     test_out <- check_df(dbReadTable(con, table_name))
@@ -35,7 +35,7 @@ spec_arrow_write_table_arrow <- list(
     #' column names,
     #' an error is raised; the remote table remains unchanged.
     test_in <- data.frame(a = 1L)
-    dbWriteTableArrow(con, table_name, test_in %>% stream_frame())
+    dbWriteTableArrow(con, table_name, stream_frame(test_in))
     expect_error(dbWriteTableArrow(con, table_name, stream_frame(b = 2L), append = TRUE))
 
     test_out <- check_df(dbReadTable(con, table_name))
@@ -59,29 +59,29 @@ spec_arrow_write_table_arrow <- list(
     #' An error is also raised
     test_in <- data.frame(a = 1L)
     #' if `name` cannot be processed with [dbQuoteIdentifier()] or
-    expect_error(dbWriteTableArrow(con, NA, test_in %>% stream_frame()))
+    expect_error(dbWriteTableArrow(con, NA, stream_frame(test_in)))
     #' if this results in a non-scalar.
-    expect_error(dbWriteTableArrow(con, c(table_name, table_name), test_in %>% stream_frame()))
+    expect_error(dbWriteTableArrow(con, c(table_name, table_name), stream_frame(test_in)))
 
     #' Invalid values for the additional arguments
     #' `overwrite`, `append`, and `temporary`
     #' (non-scalars,
-    expect_error(dbWriteTableArrow(con, table_name, test_in %>% stream_frame(), overwrite = c(TRUE, FALSE)))
-    expect_error(dbWriteTableArrow(con, table_name, test_in %>% stream_frame(), append = c(TRUE, FALSE)))
-    expect_error(dbWriteTableArrow(con, table_name, test_in %>% stream_frame(), temporary = c(TRUE, FALSE)))
+    expect_error(dbWriteTableArrow(con, table_name, stream_frame(test_in), overwrite = c(TRUE, FALSE)))
+    expect_error(dbWriteTableArrow(con, table_name, stream_frame(test_in), append = c(TRUE, FALSE)))
+    expect_error(dbWriteTableArrow(con, table_name, stream_frame(test_in), temporary = c(TRUE, FALSE)))
     #' unsupported data types,
-    expect_error(dbWriteTableArrow(con, table_name, test_in %>% stream_frame(), overwrite = 1L))
-    expect_error(dbWriteTableArrow(con, table_name, test_in %>% stream_frame(), append = 1L))
-    expect_error(dbWriteTableArrow(con, table_name, test_in %>% stream_frame(), temporary = 1L))
+    expect_error(dbWriteTableArrow(con, table_name, stream_frame(test_in), overwrite = 1L))
+    expect_error(dbWriteTableArrow(con, table_name, stream_frame(test_in), append = 1L))
+    expect_error(dbWriteTableArrow(con, table_name, stream_frame(test_in), temporary = 1L))
     #' `NA`,
-    expect_error(dbWriteTableArrow(con, table_name, test_in %>% stream_frame(), overwrite = NA))
-    expect_error(dbWriteTableArrow(con, table_name, test_in %>% stream_frame(), append = NA))
-    expect_error(dbWriteTableArrow(con, table_name, test_in %>% stream_frame(), temporary = NA))
+    expect_error(dbWriteTableArrow(con, table_name, stream_frame(test_in), overwrite = NA))
+    expect_error(dbWriteTableArrow(con, table_name, stream_frame(test_in), append = NA))
+    expect_error(dbWriteTableArrow(con, table_name, stream_frame(test_in), temporary = NA))
     #' incompatible values,
-    expect_error(dbWriteTableArrow(con, table_name, test_in %>% stream_frame(), overwrite = TRUE, append = TRUE))
+    expect_error(dbWriteTableArrow(con, table_name, stream_frame(test_in), overwrite = TRUE, append = TRUE))
 
     #' incompatible columns)
-    dbWriteTableArrow(con, table_name, test_in %>% stream_frame())
+    dbWriteTableArrow(con, table_name, stream_frame(test_in))
     expect_error(dbWriteTableArrow(con, table_name, stream_frame(b = 2L, c = 3L), append = TRUE))
 
     #' also raise an error.
@@ -112,7 +112,7 @@ spec_arrow_write_table_arrow <- list(
       test_in <- data.frame(a = 1)
       local_remove_test_table(con, table_name)
       #' - If an unquoted table name as string: `dbWriteTableArrow()` will do the quoting,
-      dbWriteTableArrow(con, table_name, test_in %>% stream_frame())
+      dbWriteTableArrow(con, table_name, stream_frame(test_in))
       test_out <- check_df(dbReadTable(con, dbQuoteIdentifier(con, table_name)))
       expect_equal_df(test_out, test_in)
       #'   perhaps by calling `dbQuoteIdentifier(conn, x = name)`
@@ -133,7 +133,7 @@ spec_arrow_write_table_arrow <- list(
       test_in <- data.frame(a = 1)
 
       local_remove_test_table(con, table_name)
-      dbWriteTableArrow(con, dbQuoteIdentifier(con, table_name), test_in %>% stream_frame())
+      dbWriteTableArrow(con, dbQuoteIdentifier(con, table_name), stream_frame(test_in))
       test_out <- check_df(dbReadTable(con, table_name))
       expect_equal_df(test_out, test_in)
     }
@@ -143,7 +143,7 @@ spec_arrow_write_table_arrow <- list(
   arrow_write_table_arrow_value_df = function(con, table_name) {
     #' The `value` argument must be a data frame
     test_in <- trivial_df()
-    dbWriteTableArrow(con, table_name, test_in %>% stream_frame())
+    dbWriteTableArrow(con, table_name, stream_frame(test_in))
 
     test_out <- check_df(dbReadTable(con, table_name))
     expect_equal_df(test_out, test_in)
@@ -153,7 +153,7 @@ spec_arrow_write_table_arrow <- list(
     #' with a subset of the columns of the existing table if `append = TRUE`.
     test_in <- trivial_df(3, letters[1:3])
     dbCreateTable(con, table_name, test_in)
-    dbWriteTableArrow(con, table_name, test_in[2] %>% stream_frame(), append = TRUE)
+    dbWriteTableArrow(con, table_name, stream_frame(test_in[2]), append = TRUE)
 
     test_out <- check_df(dbReadTable(con, table_name))
 
@@ -165,7 +165,7 @@ spec_arrow_write_table_arrow <- list(
     #' The order of the columns does not matter with `append = TRUE`.
     test_in <- trivial_df(3, letters[1:3])
     dbCreateTable(con, table_name, test_in)
-    dbWriteTableArrow(con, table_name, test_in[c(2, 3, 1)] %>% stream_frame(), append = TRUE)
+    dbWriteTableArrow(con, table_name, stream_frame(test_in[c(2, 3, 1)]), append = TRUE)
 
     test_out <- check_df(dbReadTable(con, table_name))
     expect_equal_df(test_out, test_in)
@@ -175,7 +175,7 @@ spec_arrow_write_table_arrow <- list(
   arrow_write_table_arrow_value_shuffle_subset = function(ctx, con, table_name) {
     test_in <- trivial_df(4, letters[1:4])
     dbCreateTable(con, table_name, test_in)
-    dbWriteTableArrow(con, table_name, test_in[c(4, 1, 3)] %>% stream_frame(), append = TRUE)
+    dbWriteTableArrow(con, table_name, stream_frame(test_in[c(4, 1, 3)]), append = TRUE)
 
     test_out <- check_df(dbReadTable(con, table_name))
 
@@ -192,7 +192,7 @@ spec_arrow_write_table_arrow <- list(
     penguins <- get_penguins(ctx)
     dbWriteTableArrow(con, table_name, penguins)
     expect_error(
-      dbWriteTableArrow(con, table_name, penguins[1, ] %>% stream_frame(), overwrite = TRUE),
+      dbWriteTableArrow(con, table_name, stream_frame(penguins[1, ]), overwrite = TRUE),
       NA
     )
     penguins_out <- check_df(dbReadTable(con, table_name))
@@ -205,7 +205,7 @@ spec_arrow_write_table_arrow <- list(
     #' This argument doesn't change behavior if the table does not exist yet.
     penguins_in <- get_penguins(ctx)
     expect_error(
-      dbWriteTableArrow(con, table_name, penguins_in[1, ] %>% stream_frame(), overwrite = TRUE),
+      dbWriteTableArrow(con, table_name, stream_frame(penguins_in[1, ]), overwrite = TRUE),
       NA
     )
     penguins_out <- check_df(dbReadTable(con, table_name))
@@ -220,7 +220,7 @@ spec_arrow_write_table_arrow <- list(
     #' preserved, and the new data are appended.
     penguins <- get_penguins(ctx)
     dbWriteTableArrow(con, table_name, penguins)
-    expect_error(dbWriteTableArrow(con, table_name, penguins[1, ] %>% stream_frame(), append = TRUE), NA)
+    expect_error(dbWriteTableArrow(con, table_name, stream_frame(penguins[1, ]), append = TRUE), NA)
     penguins_out <- check_df(dbReadTable(con, table_name))
     expect_equal_df(penguins_out, rbind(penguins, penguins[1, ]))
   },
@@ -230,7 +230,7 @@ spec_arrow_write_table_arrow <- list(
 
     #' If the table doesn't exist yet, it is created.
     penguins <- get_penguins(ctx)
-    expect_error(dbWriteTableArrow(con, table_name, penguins[1, ] %>% stream_frame(), append = TRUE), NA)
+    expect_error(dbWriteTableArrow(con, table_name, stream_frame(penguins[1, ]), append = TRUE), NA)
     penguins_out <- check_df(dbReadTable(con, table_name))
     expect_equal_df(penguins_out, penguins[1, ])
   },
@@ -247,7 +247,7 @@ spec_arrow_write_table_arrow <- list(
     }
 
     penguins <- get_penguins(ctx)
-    dbWriteTableArrow(con, table_name, penguins %>% stream_frame(), temporary = TRUE)
+    dbWriteTableArrow(con, table_name, stream_frame(penguins), temporary = TRUE)
     penguins_out <- check_df(dbReadTable(con, table_name))
     expect_equal_df(penguins_out, penguins)
 
@@ -278,7 +278,7 @@ spec_arrow_write_table_arrow <- list(
     # removed at the end of the test
     table_name <- "dbit09"
 
-    dbWriteTableArrow(local_con, table_name, penguins30 %>% stream_frame())
+    dbWriteTableArrow(local_con, table_name, stream_frame(penguins30))
     penguins_out <- check_df(dbReadTable(local_con, table_name))
     expect_equal_df(penguins_out, penguins30)
 
@@ -741,10 +741,10 @@ test_arrow_roundtrip_one <- function(con, tbl_in, tbl_expected = tbl_in, transfo
   local_remove_test_table(con, name = name)
 
   if (use_append) {
-    dbCreateTableArrow(con, name, tbl_in %>% stream_frame())
-    dbAppendTableArrow(con, name, tbl_in %>% stream_frame())
+    dbCreateTableArrow(con, name, stream_frame(tbl_in))
+    dbAppendTableArrow(con, name, stream_frame(tbl_in))
   } else {
-    dbWriteTableArrow(con, name, tbl_in %>% stream_frame())
+    dbWriteTableArrow(con, name, stream_frame(tbl_in))
   }
 
   stream <- dbReadTableArrow(con, name)

--- a/R/spec-result-roundtrip.R
+++ b/R/spec-result-roundtrip.R
@@ -21,7 +21,10 @@ spec_result_roundtrip <- list(
   data_logical = function(ctx, con) {
     #' - [logical] for Boolean values (some backends may return an integer);
     int_values <- 1:0
-    values <- ctx$tweaks$logical_return(as.logical(int_values))
+    values <- purrr::map(
+      ctx$tweaks$logical_return(as.logical(int_values)),
+      logical_value_equals
+    )
 
     sql_names <- paste0("CAST(", int_values, " AS ", dbDataType(con, logical()), ")")
 
@@ -353,6 +356,19 @@ equals_one <- function(x) {
 
 equals_minus_100 <- function(x) {
   identical(as.integer(x), -100L) && identical(as.numeric(x), -100)
+}
+
+logical_value_equals <- function(expected) {
+  expected_logical <- scalar_as_logical(expected)
+  function(value) identical(scalar_as_logical(value), expected_logical)
+}
+
+scalar_as_logical <- function(x) {
+  if (is.list(x)) {
+    x <- x[[1L]]
+  }
+
+  as.logical(x)
 }
 
 all_have_utf8_or_ascii_encoding <- function(x) {

--- a/tests/testthat/test-logical-return.R
+++ b/tests/testthat/test-logical-return.R
@@ -1,0 +1,29 @@
+skip_if_not_installed("bit64")
+skip_if_not_installed("RSQLite")
+
+make_integer64_logical_context <- function(logical_return) {
+  DBItest::make_context(
+    RSQLite::SQLite(),
+    list(
+      dbname = tempfile("DBItest", fileext = ".sqlite"),
+      bigint = "integer64"
+    ),
+    tweaks = DBItest::tweaks(logical_return = logical_return)
+  )
+}
+
+test_that("data_logical accepts integer64 vector tweaks", {
+  on.exit(DBItest::set_default_context(NULL), add = TRUE)
+
+  ctx <- make_integer64_logical_context(function(x) bit64::as.integer64(x))
+
+  expect_no_error(DBItest::test_some("data_logical", ctx = ctx))
+})
+
+test_that("data_logical accepts integer64 list tweaks", {
+  on.exit(DBItest::set_default_context(NULL), add = TRUE)
+
+  ctx <- make_integer64_logical_context(function(x) lapply(x, bit64::as.integer64))
+
+  expect_no_error(DBItest::test_some("data_logical", ctx = ctx))
+})


### PR DESCRIPTION
Summary

Make `data_logical` compare boolean values by logical meaning rather than by
the exact storage class returned by a backend. This keeps the spec narrow
while allowing `logical_return` tweaks that surface `bit64::integer64`
scalars.

Thanks to maintainers

Thanks for maintaining `DBItest`, and for the prior discussion on `#308` and
`#309` about the intended scope of `logical_return`.

Issue or motivation

`data_logical` currently fails when a backend-specific `logical_return` tweak
returns `bit64::integer64` values. The failure persists on the current
`DBItest` release with a local `RSQLite` repro and still blocks the kind of
integer64-returning backend discussed in `#308`.

Root cause

`data_logical` builds exact expected scalars from `logical_return()` and then
asserts `expect_identical()` on the fetched value. That makes the spec depend
on the backend's exact carrier class for booleans, even though the spec text
already allows booleans to come back as integers.

Change

- Convert `data_logical` expectations into scalar predicates that compare by
  logical value.
- Handle both vector-returning and list-returning `logical_return` tweaks.
- Add regression coverage for `bit64::integer64` tweaks in both forms.
- Declare `bit64` in `Suggests`, which the new regression test uses.
- Replace magrittr pipes in the Arrow spec files with ordinary function calls
  so the package lint job can run with the current pipe-consistency rule
  without changing the package's R version requirement.

Tests

- `LINTR_ERROR_ON_LINT=true Rscript -e 'lintr::lint_package()'`
- `Rscript -e 'pkgload::load_all(".", quiet = TRUE); testthat::test_file("tests/testthat/test-logical-return.R")'`
- `Rscript -e 'pkgload::load_all(".", quiet = TRUE); ctx <- DBItest::make_context(RSQLite::SQLite(), list(dbname = tempfile("DBItest", fileext = ".sqlite")), tweaks = DBItest::tweaks(dbitest_version = "1.8.2.9019")); DBItest::test_some(c("arrow_create_table_arrow_overwrite", "arrow_append_table_arrow_invalid_value", "arrow_write_table_arrow_error"), ctx = ctx)'`
- `git diff --check`
- `R CMD build .`
- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual DBItest_1.8.2.9019.tar.gz`

Scope

This stays within the `data_logical` roundtrip spec and the lint-only Arrow
spec cleanup needed by this PR branch. It does not change `expect_equal_df()`,
broader integer64 comparison rules for table roundtrips, Arrow behavior, or the
semantics of other `bigint`-related specs such as `#311` or `#412`.
