### PR TITLE
ci: fix `backends odbc` workflow (unixODBC headers + MariaDB driver install)

### DIFF
--- a/.github/odbc/install-mariadb-driver.sh
+++ b/.github/odbc/install-mariadb-driver.sh
@@ -1,28 +1,13 @@
-set -x
+set -ex
 
-# from https://mariadb.com/kb/en/about-mariadb-connector-odbc/#installing-mariadb-connectorodbc-on-debianubuntu
-mkdir odbc_package
-pushd odbc_package
-wget https://downloads.mariadb.com/Connectors/odbc/connector-odbc-3.1.9/mariadb-connector-odbc-3.1.9-ubuntu-focal-amd64.tar.gz
-tar -xvzf mariadb-connector-odbc-3.1.9-ubuntu-focal-amd64.tar.gz
-cd mariadb-connector-odbc-3.1.9-ubuntu-focal-amd64
-sudo install lib/mariadb/libmaodbc.so /usr/lib/
-cd ..
-
-ldd /usr/lib/libmaodbc.so
-
-wget https://downloads.mariadb.com/Connectors/c/connector-c-3.1.9/mariadb-connector-c-3.1.9-ubuntu-focal-amd64.tar.gz
-tar -xvzf mariadb-connector-c-3.1.9-ubuntu-focal-amd64.tar.gz
-cd mariadb-connector-c-3.1.9-ubuntu-focal-amd64
-sudo install -d /usr/local/lib64/mariadb/
-sudo install -d /usr/local/lib64/mariadb/plugin/
-sudo install lib/mariadb/plugin/auth_gssapi_client.so /usr/local/lib64/mariadb/plugin/
-sudo install lib/mariadb/plugin/caching_sha2_password.so /usr/local/lib64/mariadb/plugin/
-sudo install lib/mariadb/plugin/client_ed25519.so /usr/local/lib64/mariadb/plugin/
-sudo install lib/mariadb/plugin/dialog.so /usr/local/lib64/mariadb/plugin/
-sudo install lib/mariadb/plugin/mysql_clear_password.so /usr/local/lib64/mariadb/plugin/
-sudo install lib/mariadb/plugin/sha256_password.so /usr/local/lib64/mariadb/plugin/
-cd ..
-
-popd
-rm -r odbc_package
+# Install the MariaDB ODBC driver from the Ubuntu archive.
+# This pulls in libmariadb3, which ships the connector-C authentication
+# plugins (e.g. caching_sha2_password, needed to authenticate against MySQL 8)
+# in its own default plugin directory, so no manual plugin placement is needed.
+# The driver is installed at /usr/lib/x86_64-linux-gnu/odbc/libmaodbc.so, which
+# the "MySQL Driver" entry in .github/odbc/odbcinst.ini points to.
+#
+# This replaces a manual download from downloads.mariadb.com that pinned an old
+# focal-only build (3.1.9) and had become unreliable (the CDN returned HTTP 522,
+# leaving libmaodbc.so uninstalled and the backend tests unable to connect).
+sudo apt-get install -y odbc-mariadb

--- a/.github/odbc/odbcinst.ini
+++ b/.github/odbc/odbcinst.ini
@@ -7,7 +7,7 @@ FileUsage=1
 Threading=2
 
 [MySQL Driver]
-Driver=/usr/lib/libmaodbc.so
+Driver=/usr/lib/x86_64-linux-gnu/odbc/libmaodbc.so
 UsageCount = 1
 Threading=2
 

--- a/.github/workflows/odbc.yaml
+++ b/.github/workflows/odbc.yaml
@@ -125,6 +125,19 @@ jobs:
         shell: Rscript {0}
 
       # Begin custom: after install
+      # The odbc package is compiled from source below (in "Install locally to
+      # avoid error with test_local()", and silently during "Install package
+      # and dependencies" because R_REMOTES_NO_ERRORS_FROM_WARNINGS demotes the
+      # failure to a warning).
+      # That build needs the unixODBC driver-manager development headers (sql.h)
+      # and libodbc, which the database-specific driver installs below do not
+      # provide -- they add drivers, not the driver manager.
+      # Install it explicitly for every backend so the source build succeeds.
+      - name: Install unixODBC driver manager
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install -y unixodbc-dev
+
       - name: Setup MySQL
         if: matrix.database == 'mysql'
         run: |


### PR DESCRIPTION
## Problem

The scheduled `backends odbc` workflow has been failing for over a month. The `matrix` setup job succeeds, but the `mysql` backend child job fails. Fixing it surfaced two independent causes, addressed in two commits.

## Cause 1 — missing unixODBC development headers

The job failed at **"Install locally to avoid error with test_local()"** (`R CMD INSTALL revdep-dev/odbc`) with:

```
<stdin>:1:10: fatal error: sql.h: No such file or directory
ERROR: configuration failed for package 'odbc'
```

Compiling `odbc` from source needs the unixODBC **driver-manager** development headers (`sql.h`) + `libodbc`, from `unixodbc-dev`. The database-specific driver steps only install *drivers*, not the driver *manager*; the `mysql` path (the only active matrix entry per `revdep-dev/Makefile`) never installed `unixodbc-dev`. The earlier "Install package and dependencies" step hit the same error but hid it, because `R_REMOTES_NO_ERRORS_FROM_WARNINGS: true` demotes it to a warning.

**Fix:** add an always-run (Linux) step installing `unixodbc-dev` before the source build.

## Cause 2 — MariaDB ODBC driver never installed

With the headers in place, the source build now succeeds and the job reaches **"Test backend"**, which then failed with:

```
[unixODBC][Driver Manager]Can't open lib '/usr/lib/libmaodbc.so' : file not found
```

`.github/odbc/install-mariadb-driver.sh` downloaded a pinned focal-only build (3.1.9) from `downloads.mariadb.com`, which returned **HTTP 522** (CDN origin timeout). With no `set -e`, the failed download was masked — "Setup MySQL" reported success but `libmaodbc.so` was never installed.

**Fix:** install the driver from the Ubuntu archive (`odbc-mariadb`) instead, matching how the other backends install their drivers. It also pulls in `libmariadb3` with the connector-C auth plugins (e.g. `caching_sha2_password` for MySQL 8) in their default location, so the manual plugin placement is dropped. `odbcinst.ini`'s `[MySQL Driver]` now points at the package path (`/usr/lib/x86_64-linux-gnu/odbc/libmaodbc.so`), and `set -e` is added so a future install failure is no longer silently ignored.

## Verification

- `odbc.yaml` parses as valid YAML; new step ordered before the odbc source build.
- Confirmed on Ubuntu 24.04 that `unixodbc-dev` provides `/usr/include/sql.h` and that `odbc-mariadb` installs a loadable driver at `/usr/lib/x86_64-linux-gnu/odbc/libmaodbc.so` (all shared-lib deps resolve); unixODBC reads the repo `odbcinst.ini` via `ODBCSYSINI` with `[MySQL Driver]` present.
- The first fix is already confirmed by CI: on the previous PR-head run the `R CMD INSTALL revdep-dev/odbc` step went from failing to passing.

> Note: the separate `lint` check is red due to pre-existing `pipe_consistency_linter`/`expect_shape_linter` findings in `R/spec-*.R` and `R/utils.R` (the `lint` workflow has failed on `main` since well before this branch). Those files are untouched by this PR, so that failure is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BRYo2D5L4wpgaTFTHH2B7