### PR TITLE
ci: Fix MySQL ODBC backend workflow

### DIFF
--- a/.github/odbc/install-mariadb-driver.sh
+++ b/.github/odbc/install-mariadb-driver.sh
@@ -1,28 +1,20 @@
-set -x
+#!/usr/bin/env bash
+set -ex
 
-# from https://mariadb.com/kb/en/about-mariadb-connector-odbc/#installing-mariadb-connectorodbc-on-debianubuntu
-mkdir odbc_package
-pushd odbc_package
-wget https://downloads.mariadb.com/Connectors/odbc/connector-odbc-3.1.9/mariadb-connector-odbc-3.1.9-ubuntu-focal-amd64.tar.gz
-tar -xvzf mariadb-connector-odbc-3.1.9-ubuntu-focal-amd64.tar.gz
-cd mariadb-connector-odbc-3.1.9-ubuntu-focal-amd64
-sudo install lib/mariadb/libmaodbc.so /usr/lib/
-cd ..
+# Install the unixODBC driver manager (headers + runtime) and the MariaDB
+# Connector/ODBC driver from the Ubuntu package repositories.
+#
+# This previously downloaded prebuilt tarballs from downloads.mariadb.com, but
+# those URLs now return HTTP 522 and the pinned "focal" builds are incompatible
+# with the ubuntu-24.04 runner.  The distro packages are self-contained and
+# maintained:
+#   * unixodbc-dev provides sql.h, needed to compile the odbc R package.
+#   * odbc-mariadb installs libmaodbc.so to /usr/lib/x86_64-linux-gnu/odbc/ and
+#     pulls in libmariadb3, which ships the authentication plugins (including
+#     caching_sha2_password, required to connect to MySQL 8) in its default
+#     plugin directory, so no manual plugin installation is required.
+sudo apt-get update
+sudo apt-get install -y unixodbc-dev odbc-mariadb
 
-ldd /usr/lib/libmaodbc.so
-
-wget https://downloads.mariadb.com/Connectors/c/connector-c-3.1.9/mariadb-connector-c-3.1.9-ubuntu-focal-amd64.tar.gz
-tar -xvzf mariadb-connector-c-3.1.9-ubuntu-focal-amd64.tar.gz
-cd mariadb-connector-c-3.1.9-ubuntu-focal-amd64
-sudo install -d /usr/local/lib64/mariadb/
-sudo install -d /usr/local/lib64/mariadb/plugin/
-sudo install lib/mariadb/plugin/auth_gssapi_client.so /usr/local/lib64/mariadb/plugin/
-sudo install lib/mariadb/plugin/caching_sha2_password.so /usr/local/lib64/mariadb/plugin/
-sudo install lib/mariadb/plugin/client_ed25519.so /usr/local/lib64/mariadb/plugin/
-sudo install lib/mariadb/plugin/dialog.so /usr/local/lib64/mariadb/plugin/
-sudo install lib/mariadb/plugin/mysql_clear_password.so /usr/local/lib64/mariadb/plugin/
-sudo install lib/mariadb/plugin/sha256_password.so /usr/local/lib64/mariadb/plugin/
-cd ..
-
-popd
-rm -r odbc_package
+# Confirm the driver is present and its shared-library dependencies resolve.
+ldd /usr/lib/x86_64-linux-gnu/odbc/libmaodbc.so

--- a/.github/odbc/odbcinst.ini
+++ b/.github/odbc/odbcinst.ini
@@ -7,7 +7,7 @@ FileUsage=1
 Threading=2
 
 [MySQL Driver]
-Driver=/usr/lib/libmaodbc.so
+Driver=/usr/lib/x86_64-linux-gnu/odbc/libmaodbc.so
 UsageCount = 1
 Threading=2
 

--- a/.github/workflows/odbc.yaml
+++ b/.github/workflows/odbc.yaml
@@ -50,7 +50,8 @@ jobs:
 
   backend:
     needs: matrix
-    # Need Ubuntu 24.04 for remotes::system_requirements()
+    # Ubuntu 24.04 matches the driver packages installed below (e.g. the
+    # msodbcsql17 repo config and the distro odbc-mariadb driver).
     runs-on: ubuntu-24.04
 
     services:
@@ -94,7 +95,10 @@ jobs:
         with:
           cache-version: backends-${{ matrix.package }}
           needs: check
-          extra-packages: "any::pkgbuild any::remotes decor ."
+          # remotes from GitHub: the CRAN release (2.5.0) does not yet know
+          # Ubuntu 24.04, so its system_requirements() aborts on the 24.04
+          # runner below. The dev version adds 24.04 to its supported list.
+          extra-packages: "any::pkgbuild github::r-lib/remotes decor ."
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clone backend
@@ -103,7 +107,11 @@ jobs:
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
-        # "22.04" fails here
+        # Relies on the dev version of remotes installed above; the CRAN release
+        # 2.5.0 only knows Ubuntu releases up to "22.04", so "24.04" aborts with
+        # a match.arg() error that the process substitution silently swallows,
+        # installing nothing (which is how unixodbc-dev went missing and odbc
+        # failed to compile with "sql.h: No such file or directory").
         run: |
           while read -r cmd
           do


### PR DESCRIPTION
## Problem

The `backends odbc` workflow (`.github/workflows/odbc.yaml`) has been failing on its `mysql` job. Investigating the [failing run](https://github.com/r-dbi/DBItest/actions/runs/29954472543) showed three interacting failures:

1. **`system_requirements()` installs nothing.** The step runs `remotes::system_requirements("ubuntu", "24.04", …)`. The **CRAN release** of `remotes` (2.5.0) that CI installs does not yet know Ubuntu 24.04 — its supported list stops at 22.04 — so the call aborts with a `match.arg()` error that is hidden by the `done < <(…)` process substitution. No system dependencies are installed, including `unixodbc-dev`, and the `odbc` package then fails to compile:

   ```
   <stdin>:1:10: fatal error: sql.h: No such file or directory
   ------------------------- ANTICONF ERROR ---------------------------
   Configuration failed because odbc was not found.
   ```

   (The **dev** version of `remotes` does list 24.04, but it is unreleased and not on CRAN.)

2. **The MariaDB driver never installs.** `install-mariadb-driver.sh` downloads pinned `3.1.9` `ubuntu-focal` tarballs from `downloads.mariadb.com`, which now return **HTTP 522**. Because the script used `set -x` but not `set -e`, it silently continued, leaving no driver installed. The `focal` builds are also incompatible with the `ubuntu-24.04` runner (they need `libssl1.1`).

3. **`odbcinst.ini` pointed at the wrong path** (`/usr/lib/libmaodbc.so`), the location the old tarball wrote to.

## Fix

- Install the dev version of `remotes` (`github::r-lib/remotes`), which knows Ubuntu 24.04, so `system_requirements("ubuntu", "24.04", …)` succeeds and yields `unixodbc-dev`. The query stays aligned with the actual runner OS.
- Replace the tarball download with an apt install of `unixodbc-dev` and `odbc-mariadb`. `odbc-mariadb` pulls in `libmariadb3`, which ships the authentication plugins (including `caching_sha2_password`, required for MySQL 8) in its default plugin directory — so no manual plugin installation is needed.
- Add `set -e` to the driver script so install failures surface instead of being silently ignored.
- Point the `[MySQL Driver]` entry in `odbcinst.ini` at `/usr/lib/x86_64-linux-gnu/odbc/libmaodbc.so`, where the `odbc-mariadb` package installs the driver.

## Verification

Reproduced the runner setup on Ubuntu 24.04 (noble):

- `apt-get install unixodbc-dev odbc-mariadb` installs `libmaodbc.so` at the configured path; `ldd` resolves every dependency (against `libssl.so.3`/`libcrypto.so.3`, present on noble).
- `sql.h` is present and a C program using `sql.h`/`sqlext.h` compiles and links with `-lodbc` (`INCLUDE_DIR=/usr/include LIB_DIR=/usr/lib/x86_64-linux-gnu/`), matching the flags the `odbc` package's `R CMD INSTALL` step uses.
- Confirmed the CRAN `remotes` 2.5.0 in the environment errors on `"24.04"` (its supported list ends at `22.04`), while the r-lib/remotes `main` source lists `"24.04"`.
- unixODBC reads the config and registers `[MySQL Driver]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)