### PR TITLE
fix: replace legacy `PST8PDT` time zone with `America/Los_Angeles` in roundtrip tests

### DIFF
--- a/R/spec-arrow-append-table-arrow.R
+++ b/R/spec-arrow-append-table-arrow.R
@@ -400,7 +400,7 @@ spec_arrow_append_table_arrow <- list(
     tbl_in <- data.frame(id = seq_along(local))
     tbl_in$local <- local
     tbl_in$gmt <- lubridate::with_tz(local, tzone = "GMT")
-    tbl_in$pst8pdt <- lubridate::with_tz(local, tzone = "PST8PDT")
+    tbl_in$los_angeles <- lubridate::with_tz(local, tzone = "America/Los_Angeles")
     tbl_in$utc <- lubridate::with_tz(local, tzone = "UTC")
 
     #'   respecting the time zone but not necessarily preserving the
@@ -412,6 +412,7 @@ spec_arrow_append_table_arrow <- list(
         dates <- map_lgl(out, inherits, "POSIXt")
         tz <- toupper(names(out))
         tz[tz == "LOCAL"] <- ""
+        tz[tz == "LOS_ANGELES"] <- "America/Los_Angeles"
         out[dates] <- Map(lubridate::with_tz, out[dates], tz[dates])
         out
       }
@@ -443,7 +444,7 @@ spec_arrow_append_table_arrow <- list(
     tbl_in <- data.frame(id = seq_along(local))
     tbl_in$local <- local
     tbl_in$gmt <- lubridate::with_tz(local, tzone = "GMT")
-    tbl_in$pst8pdt <- lubridate::with_tz(local, tzone = "PST8PDT")
+    tbl_in$los_angeles <- lubridate::with_tz(local, tzone = "America/Los_Angeles")
     tbl_in$utc <- lubridate::with_tz(local, tzone = "UTC")
 
     #'   respecting the time zone but not necessarily preserving the
@@ -455,6 +456,7 @@ spec_arrow_append_table_arrow <- list(
         dates <- map_lgl(out, inherits, "POSIXt")
         tz <- toupper(names(out))
         tz[tz == "LOCAL"] <- ""
+        tz[tz == "LOS_ANGELES"] <- "America/Los_Angeles"
         out[dates] <- Map(lubridate::with_tz, out[dates], tz[dates])
         out
       }

--- a/R/spec-arrow-write-table-arrow.R
+++ b/R/spec-arrow-write-table-arrow.R
@@ -635,7 +635,7 @@ spec_arrow_write_table_arrow <- list(
     tbl_in <- data.frame(id = seq_along(local))
     tbl_in$local <- local
     tbl_in$gmt <- lubridate::with_tz(local, tzone = "GMT")
-    tbl_in$pst8pdt <- lubridate::with_tz(local, tzone = "PST8PDT")
+    tbl_in$los_angeles <- lubridate::with_tz(local, tzone = "America/Los_Angeles")
     tbl_in$utc <- lubridate::with_tz(local, tzone = "UTC")
 
     #'   respecting the time zone but not necessarily preserving the
@@ -646,6 +646,7 @@ spec_arrow_write_table_arrow <- list(
         dates <- map_lgl(out, inherits, "POSIXt")
         tz <- toupper(names(out))
         tz[tz == "LOCAL"] <- ""
+        tz[tz == "LOS_ANGELES"] <- "America/Los_Angeles"
         out[dates] <- Map(lubridate::with_tz, out[dates], tz[dates])
         out
       }
@@ -677,7 +678,7 @@ spec_arrow_write_table_arrow <- list(
     tbl_in <- data.frame(id = seq_along(local))
     tbl_in$local <- local
     tbl_in$gmt <- lubridate::with_tz(local, tzone = "GMT")
-    tbl_in$pst8pdt <- lubridate::with_tz(local, tzone = "PST8PDT")
+    tbl_in$los_angeles <- lubridate::with_tz(local, tzone = "America/Los_Angeles")
     tbl_in$utc <- lubridate::with_tz(local, tzone = "UTC")
 
     #'   respecting the time zone but not necessarily preserving the
@@ -688,6 +689,7 @@ spec_arrow_write_table_arrow <- list(
         dates <- map_lgl(out, inherits, "POSIXt")
         tz <- toupper(names(out))
         tz[tz == "LOCAL"] <- ""
+        tz[tz == "LOS_ANGELES"] <- "America/Los_Angeles"
         out[dates] <- Map(lubridate::with_tz, out[dates], tz[dates])
         out
       }

--- a/R/spec-sql-append-table.R
+++ b/R/spec-sql-append-table.R
@@ -407,7 +407,7 @@ spec_sql_append_table <- list(
     tbl_in <- data.frame(id = seq_along(local))
     tbl_in$local <- local
     tbl_in$gmt <- lubridate::with_tz(local, tzone = "GMT")
-    tbl_in$pst8pdt <- lubridate::with_tz(local, tzone = "PST8PDT")
+    tbl_in$los_angeles <- lubridate::with_tz(local, tzone = "America/Los_Angeles")
     tbl_in$utc <- lubridate::with_tz(local, tzone = "UTC")
 
     #'   respecting the time zone but not necessarily preserving the
@@ -419,6 +419,7 @@ spec_sql_append_table <- list(
         dates <- map_lgl(out, inherits, "POSIXt")
         tz <- toupper(names(out))
         tz[tz == "LOCAL"] <- ""
+        tz[tz == "LOS_ANGELES"] <- "America/Los_Angeles"
         out[dates] <- Map(lubridate::with_tz, out[dates], tz[dates])
         out
       }
@@ -448,7 +449,7 @@ spec_sql_append_table <- list(
     tbl_in <- data.frame(id = seq_along(local))
     tbl_in$local <- local
     tbl_in$gmt <- lubridate::with_tz(local, tzone = "GMT")
-    tbl_in$pst8pdt <- lubridate::with_tz(local, tzone = "PST8PDT")
+    tbl_in$los_angeles <- lubridate::with_tz(local, tzone = "America/Los_Angeles")
     tbl_in$utc <- lubridate::with_tz(local, tzone = "UTC")
 
     #'   respecting the time zone but not necessarily preserving the
@@ -460,6 +461,7 @@ spec_sql_append_table <- list(
         dates <- map_lgl(out, inherits, "POSIXt")
         tz <- toupper(names(out))
         tz[tz == "LOCAL"] <- ""
+        tz[tz == "LOS_ANGELES"] <- "America/Los_Angeles"
         out[dates] <- Map(lubridate::with_tz, out[dates], tz[dates])
         out
       }

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -617,7 +617,7 @@ spec_sql_write_table <- list(
     tbl_in <- data.frame(id = seq_along(local))
     tbl_in$local <- local
     tbl_in$gmt <- lubridate::with_tz(local, tzone = "GMT")
-    tbl_in$pst8pdt <- lubridate::with_tz(local, tzone = "PST8PDT")
+    tbl_in$los_angeles <- lubridate::with_tz(local, tzone = "America/Los_Angeles")
     tbl_in$utc <- lubridate::with_tz(local, tzone = "UTC")
 
     #'   respecting the time zone but not necessarily preserving the
@@ -628,6 +628,7 @@ spec_sql_write_table <- list(
         dates <- map_lgl(out, inherits, "POSIXt")
         tz <- toupper(names(out))
         tz[tz == "LOCAL"] <- ""
+        tz[tz == "LOS_ANGELES"] <- "America/Los_Angeles"
         out[dates] <- Map(lubridate::with_tz, out[dates], tz[dates])
         out
       }
@@ -657,7 +658,7 @@ spec_sql_write_table <- list(
     tbl_in <- data.frame(id = seq_along(local))
     tbl_in$local <- local
     tbl_in$gmt <- lubridate::with_tz(local, tzone = "GMT")
-    tbl_in$pst8pdt <- lubridate::with_tz(local, tzone = "PST8PDT")
+    tbl_in$los_angeles <- lubridate::with_tz(local, tzone = "America/Los_Angeles")
     tbl_in$utc <- lubridate::with_tz(local, tzone = "UTC")
 
     #'   respecting the time zone but not necessarily preserving the
@@ -668,6 +669,7 @@ spec_sql_write_table <- list(
         dates <- map_lgl(out, inherits, "POSIXt")
         tz <- toupper(names(out))
         tz[tz == "LOCAL"] <- ""
+        tz[tz == "LOS_ANGELES"] <- "America/Los_Angeles"
         out[dates] <- Map(lubridate::with_tz, out[dates], tz[dates])
         out
       }


### PR DESCRIPTION
## Problem

The timestamp roundtrip specs use `"PST8PDT"` as an arbitrary non-UTC time zone (alongside `"GMT"` and `"UTC"`) in `roundtrip_timestamp` and `roundtrip_timestamp_extended`, for both the SQL and Arrow write/append table specs.

`PST8PDT` is a POSIX-style **legacy** zone. Recent `tzdata` splits these legacy zones (`PST8PDT`, `EST5EDT`, `CST6CDT`, `MST7MDT`, `EST`, `MST`, `HST`) out of the main `tzdata` package into a separate `tzdata-legacy` package. I verified this in a fresh `ubuntu:26.04` container (`tzdata 2026b`):

- installing **main `tzdata` only** → `PST8PDT` and the other POSIX zones are **absent**;
- `tzdata` does **not** even `Recommends: tzdata-legacy`, so a default install never pulls it in;
- installing `tzdata-legacy` restores them.

On such systems `lubridate::with_tz(x, "PST8PDT")` emits `Unrecognized time zone 'PST8PDT'` and falls back to UTC — which fails the tests (and silently loses the distinct-offset coverage the column is meant to provide). (On Ubuntu 24.04 these zones were still in the main package, so the failure is new to 26.04.)

## Fix

Use **`America/Los_Angeles`** instead. It is the canonical modern IANA successor to `PST8PDT` — identical PST/PDT −8/−7 behavior including DST — and as a `Continent/City` zone it ships in **core** `tzdata`, present in essentially every environment (verified present in 26.04's main `tzdata`). The specific zone is arbitrary for the purpose of these tests; this one keeps the exact same semantics while being universally available.

Because a `Continent/City` name contains a `/`, it cannot double as the column name (the transform derives the target zone from `toupper(names(out))`). It is therefore mapped explicitly in the roundtrip transform, exactly the way `"LOCAL"` already is:

```r
tz <- toupper(names(out))
tz[tz == "LOCAL"] <- ""
tz[tz == "LOS_ANGELES"] <- "America/Los_Angeles"
```

## Files changed

Both timestamp roundtrip test cases in each of:

- `R/spec-sql-write-table.R`
- `R/spec-sql-append-table.R`
- `R/spec-arrow-write-table-arrow.R`
- `R/spec-arrow-append-table-arrow.R`

## Verification

Confirmed in R (4.5.3) that `America/Los_Angeles` is in `OlsonNames()`, that the roundtrip transform normalizes input and output identically, that instants are preserved, and that the old `"PST8PDT"` path warns `Unrecognized time zone` when the zone is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtiTAgGi2JJ7C8GB1xdTDS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtiTAgGi2JJ7C8GB1xdTDS)_