### PR TITLE
ci: Silence failing linters to make lint workflow pass

### DIFF
--- a/.lintr.R
+++ b/.lintr.R
@@ -5,6 +5,7 @@ linters <- modify_defaults(
   condition_call_linter = NULL,
   cyclocomp_linter = NULL,
   expect_identical_linter = NULL,
+  expect_shape_linter = NULL, # 94 occurrences, to fix
   function_argument_linter = NULL,
   if_switch_linter = NULL, # false positive: r-lib/lintr#2835
   implicit_assignment_linter = NULL,
@@ -20,6 +21,7 @@ linters <- modify_defaults(
   object_overwrite_linter = NULL,
   object_usage_linter = NULL,
   one_call_pipe_linter = NULL,
+  pipe_consistency_linter = NULL, # 51 occurrences, to fix
   strings_as_factors_linter = NULL,
   todo_comment_linter = NULL,
   undesirable_function_linter = NULL,


### PR DESCRIPTION
## Problem

The `lint` workflow runs `lintr::lint_package()` with `LINTR_ERROR_ON_LINT: true` using the **dev** version of lintr (`r-lib/lintr`). It has been failing on `main` ([latest run](https://github.com/r-dbi/DBItest/actions/runs/29987785218)).

`.lintr.R` already follows a "start from `all_linters()`, disable everything that currently fires" strategy, but two enabled linters have violations:

| linter | occurrences | note |
| --- | ---: | --- |
| `expect_shape_linter` | 94 | dev-only linter, added upstream after `.lintr.R` was written, so it was never in the disabled list |
| `pipe_consistency_linter` | 51 | `%>%` used where the config prefers `\|>` |

Total: **145** lints → non-zero exit → red CI. (Counts are from the CI job log, i.e. the dev lintr the workflow actually uses.)

## Fix

Add both linters to the disabled list in `.lintr.R`, so `lint_package()` reports no lints and the workflow passes:

```r
  expect_shape_linter = NULL, # 94 occurrences, to fix
  ...
  pipe_consistency_linter = NULL, # 51 occurrences, to fix
```

This is configuration-only; no source is changed. It restores a green baseline so the real violations can be fixed **incrementally** — re-enabling one linter at a time, cheapest first.

## Backlog for the follow-up fixes (fewest occurrences first)

The linters currently disabled in `.lintr.R`, with occurrence counts measured via `lint_package()` against `all_linters()` (CRAN lintr 3.4.0; dev-lintr counts may differ slightly, and `expect_shape_linter` is dev-only so its 94 comes from CI):

| linter | occurrences |
| --- | ---: |
| `absolute_path_linter` | 0 (can be re-enabled immediately) |
| `if_switch_linter` | disabled for false positives (r-lib/lintr#2835) |
| `unused_import_linter` | 1 |
| `condition_call_linter` | 2 |
| `missing_argument_linter` | 2 |
| `commented_code_linter` | 4 |
| `function_argument_linter` | 4 |
| `object_length_linter` | 6 |
| `strings_as_factors_linter` | 6 |
| `todo_comment_linter` | 7 |
| `nzchar_linter` | 8 |
| `implicit_assignment_linter` | 9 |
| `object_usage_linter` | 10 |
| `cyclocomp_linter` | 12 |
| `object_name_linter` | 14 |
| `one_call_pipe_linter` | 45 |
| `keyword_quote_linter` | 50 |
| `pipe_consistency_linter` | 51 |
| `nonportable_path_linter` | 75 |
| `object_overwrite_linter` | 85 |
| `undesirable_function_linter` | 87 |
| `expect_identical_linter` | 242 |
| `namespace_linter` | 182 |
| `line_length_linter` | 880 |
| `implicit_integer_linter` | 975 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012EnbnoZUvej92b5oMNPezG)_