### PR TITLE
fix: Set `call. = FALSE` in `ctx` sentinel `stop()` calls

### DIFF
--- a/R/spec-meta-bind-.R
+++ b/R/spec-meta-bind-.R
@@ -2,7 +2,7 @@
 
 test_select_bind_expr <- function(
   bind_values,
-  ctx = stop("ctx is available during run time only"),
+  ctx = stop("ctx is available during run time only", call. = FALSE),
   ...,
   arrow,
   bind,

--- a/R/spec-meta-bind-expr.R
+++ b/R/spec-meta-bind-expr.R
@@ -9,7 +9,7 @@ spec_meta_bind_expr <- function(
   arrow = c("none", "query"),
   bind = c("df", "stream"),
   ...,
-  ctx = stop("ctx is available during run time only")
+  ctx = stop("ctx is available during run time only", call. = FALSE)
 ) {
   check_dots_empty()
   arrow <- arg_match(arrow)


### PR DESCRIPTION
Follow-up on #542: fixes the `condition_call_linter` violations (2 occurrences).

The `ctx` argument in `test_select_bind_expr()` and `spec_meta_bind_expr()` uses a `stop()` default as a "must be supplied at run time" sentinel. Adding `call. = FALSE` keeps the call out of the error message, satisfying `condition_call_linter`.

The linter itself is re-enabled in a separate final PR that updates `.lintr.R` once all the code fixes have landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvAeoWDREMgDse3TQgFDNp

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvAeoWDREMgDse3TQgFDNp)_