### PR TITLE
fix: Use `nzchar()` instead of comparing with `""`

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -115,7 +115,7 @@ get_skip_names <- function(skip) {
     return(character())
   }
   names_all <- names(spec_all)
-  names_all <- names_all[names_all != ""]
+  names_all <- names_all[nzchar(names_all)]
   skip_flags_all <- map(paste0("(?:^(?:", skip, ")(?:|_[0-9]+)$)"), grepl, names_all, perl = TRUE)
   skip_used <- map_lgl(skip_flags_all, any)
   if (!all(skip_used)) {
@@ -136,7 +136,7 @@ get_skip_names <- function(skip) {
 # When run_only is NULL, all tests are returned unchanged.
 get_run_only_tests <- function(tests, run_only) {
   names_all <- names(tests)
-  names_all <- names_all[names_all != ""]
+  names_all <- names_all[nzchar(names_all)]
   if (is.null(run_only)) {
     return(tests)
   }

--- a/R/spec-meta-column-info.R
+++ b/R/spec-meta-column-info.R
@@ -79,7 +79,7 @@ spec_meta_column_info <- list(
     expect_equal(data[["a"]], 2.5)
     #' non-empty and non-`NA` names are assigned.
     expect_false(anyNA(names(data)))
-    expect_true(all(names(data) != ""))
+    expect_true(all(nzchar(names(data))))
   },
 
   #'

--- a/R/tweaks.R
+++ b/R/tweaks.R
@@ -140,7 +140,7 @@ make_tweaks <- function(envir = parent.frame()) {
     function() {
       unknown <- list(...)
       if (length(unknown) > 0) {
-        if (is.null(names(unknown)) || any(!nzchar(names(unknown)))) {
+        if (is.null(names(unknown)) || !all(nzchar(names(unknown)))) {
           warning("All tweaks must be named", call. = FALSE)
         } else {
           warning("Unknown tweaks: ", toString(names(unknown)), call. = FALSE)

--- a/R/tweaks.R
+++ b/R/tweaks.R
@@ -140,7 +140,7 @@ make_tweaks <- function(envir = parent.frame()) {
     function() {
       unknown <- list(...)
       if (length(unknown) > 0) {
-        if (is.null(names(unknown)) || any(names(unknown) == "")) {
+        if (is.null(names(unknown)) || any(!nzchar(names(unknown)))) {
           warning("All tweaks must be named", call. = FALSE)
         } else {
           warning("Unknown tweaks: ", toString(names(unknown)), call. = FALSE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -120,7 +120,7 @@ check_df <- function(df) {
   }
 
   df_names <- names(df)
-  expect_true(all(df_names != ""))
+  expect_true(all(nzchar(df_names)))
   expect_false(anyNA(df_names))
 
   df

--- a/tests/testthat/test-consistency.R
+++ b/tests/testthat/test-consistency.R
@@ -1,11 +1,11 @@
 test_that("no unnamed specs", {
   tests <- compact(spec_all)
   vicinity <- NULL
-  if (any(names(tests) == "")) {
+  if (any(!nzchar(names(tests)))) {
     vicinity <- sort(unique(unlist(
-      map(which(names(tests) == ""), "+", -1:1)
+      map(which(!nzchar(names(tests))), "+", -1:1)
     )))
-    vicinity <- vicinity[names(tests)[vicinity] != ""]
+    vicinity <- vicinity[nzchar(names(tests)[vicinity])]
   }
   expect_null(vicinity)
 })

--- a/tests/testthat/test-consistency.R
+++ b/tests/testthat/test-consistency.R
@@ -1,7 +1,7 @@
 test_that("no unnamed specs", {
   tests <- compact(spec_all)
   vicinity <- NULL
-  if (any(!nzchar(names(tests)))) {
+  if (!all(nzchar(names(tests)))) {
     vicinity <- sort(unique(unlist(
       map(which(!nzchar(names(tests))), "+", -1:1)
     )))


### PR DESCRIPTION
Closing without merging: per maintainer preference, `x != ""` reads better than `nzchar(x)`, so `nzchar_linter` will stay disabled (with an explanatory comment) rather than fixing the code. The linter is kept off in #550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvAeoWDREMgDse3TQgFDNp