### PR TITLE
fix: Avoid implicit assignments inside `expect_warning()`

### DIFF
--- a/R/spec-arrow-send-query-arrow.R
+++ b/R/spec-arrow-send-query-arrow.R
@@ -67,7 +67,7 @@ spec_arrow_send_query_arrow <- list(
 
     #' @section Specification:
     #' No warnings occur under normal conditions.
-    expect_warning(res <- dbSendQueryArrow(con, trivial_query()), NA)
+    res <- expect_warning(dbSendQueryArrow(con, trivial_query()), NA)
     #' When done, the DBIResult object must be cleared with a call to
     #' [dbClearResult()].
     dbClearResult(res)
@@ -97,7 +97,7 @@ spec_arrow_send_query_arrow <- list(
     res1 <- dbSendQueryArrow(con, trivial_query())
     #' issuing a second query invalidates an already open result set
     #' and raises a warning.
-    expect_warning(res2 <- dbSendQueryArrow(con, "SELECT 2"))
+    res2 <- expect_warning(dbSendQueryArrow(con, "SELECT 2"))
     expect_false(dbIsValid(res1))
     #' The newly opened result set is valid
     expect_true(dbIsValid(res2))

--- a/R/spec-arrow-send-query-arrow.R
+++ b/R/spec-arrow-send-query-arrow.R
@@ -97,7 +97,7 @@ spec_arrow_send_query_arrow <- list(
     res1 <- dbSendQueryArrow(con, trivial_query())
     #' issuing a second query invalidates an already open result set
     #' and raises a warning.
-    expect_warning(res2 <- dbSendQueryArrow(con, "SELECT 2")) # nolint: implicit_assignment_linter.
+    expect_warning(res2 <- dbSendQueryArrow(con, "SELECT 2"))
     expect_false(dbIsValid(res1))
     #' The newly opened result set is valid
     expect_true(dbIsValid(res2))

--- a/R/spec-arrow-send-query-arrow.R
+++ b/R/spec-arrow-send-query-arrow.R
@@ -97,7 +97,7 @@ spec_arrow_send_query_arrow <- list(
     res1 <- dbSendQueryArrow(con, trivial_query())
     #' issuing a second query invalidates an already open result set
     #' and raises a warning.
-    res2 <- expect_warning(dbSendQueryArrow(con, "SELECT 2"))
+    expect_warning(res2 <- dbSendQueryArrow(con, "SELECT 2")) # nolint: implicit_assignment_linter.
     expect_false(dbIsValid(res1))
     #' The newly opened result set is valid
     expect_true(dbIsValid(res2))

--- a/R/spec-result-fetch.R
+++ b/R/spec-result-fetch.R
@@ -92,7 +92,7 @@ spec_result_fetch <- list(
     query <- ctx$tweaks$create_table_empty(table_name)
 
     res <- local_result(dbSendStatement(con, query))
-    expect_warning(rows <- check_df(dbFetch(res))) # nolint: implicit_assignment_linter.
+    expect_warning(rows <- check_df(dbFetch(res)))
     expect_identical(rows, data.frame())
   },
 

--- a/R/spec-result-fetch.R
+++ b/R/spec-result-fetch.R
@@ -92,7 +92,7 @@ spec_result_fetch <- list(
     query <- ctx$tweaks$create_table_empty(table_name)
 
     res <- local_result(dbSendStatement(con, query))
-    expect_warning(rows <- check_df(dbFetch(res)))
+    rows <- expect_warning(check_df(dbFetch(res)))
     expect_identical(rows, data.frame())
   },
 

--- a/R/spec-result-fetch.R
+++ b/R/spec-result-fetch.R
@@ -92,7 +92,7 @@ spec_result_fetch <- list(
     query <- ctx$tweaks$create_table_empty(table_name)
 
     res <- local_result(dbSendStatement(con, query))
-    rows <- expect_warning(check_df(dbFetch(res)))
+    expect_warning(rows <- check_df(dbFetch(res))) # nolint: implicit_assignment_linter.
     expect_identical(rows, data.frame())
   },
 

--- a/R/spec-result-send-query.R
+++ b/R/spec-result-send-query.R
@@ -63,7 +63,7 @@ spec_result_send_query <- list(
   send_query_result_valid = function(con) {
     #' @section Specification:
     #' No warnings occur under normal conditions.
-    expect_warning(res <- dbSendQuery(con, trivial_query()), NA)
+    res <- expect_warning(dbSendQuery(con, trivial_query()), NA)
     #' When done, the DBIResult object must be cleared with a call to
     #' [dbClearResult()].
     dbClearResult(res)
@@ -74,7 +74,7 @@ spec_result_send_query <- list(
     #' when the connection is closed.
     con <- connect(ctx)
     on.exit(dbDisconnect(con))
-    expect_warning(res <- dbSendQuery(con, trivial_query()), NA)
+    res <- expect_warning(dbSendQuery(con, trivial_query()), NA)
 
     expect_warning({
       dbDisconnect(con)
@@ -89,7 +89,7 @@ spec_result_send_query <- list(
     res1 <- dbSendQuery(con, trivial_query())
     #' issuing a second query invalidates an already open result set
     #' and raises a warning.
-    expect_warning(res2 <- dbSendQuery(con, "SELECT 2"))
+    res2 <- expect_warning(dbSendQuery(con, "SELECT 2"))
     expect_false(dbIsValid(res1))
     #' The newly opened result set is valid
     expect_true(dbIsValid(res2))

--- a/R/spec-result-send-query.R
+++ b/R/spec-result-send-query.R
@@ -89,7 +89,7 @@ spec_result_send_query <- list(
     res1 <- dbSendQuery(con, trivial_query())
     #' issuing a second query invalidates an already open result set
     #' and raises a warning.
-    expect_warning(res2 <- dbSendQuery(con, "SELECT 2")) # nolint: implicit_assignment_linter.
+    expect_warning(res2 <- dbSendQuery(con, "SELECT 2"))
     expect_false(dbIsValid(res1))
     #' The newly opened result set is valid
     expect_true(dbIsValid(res2))

--- a/R/spec-result-send-query.R
+++ b/R/spec-result-send-query.R
@@ -89,7 +89,7 @@ spec_result_send_query <- list(
     res1 <- dbSendQuery(con, trivial_query())
     #' issuing a second query invalidates an already open result set
     #' and raises a warning.
-    res2 <- expect_warning(dbSendQuery(con, "SELECT 2"))
+    expect_warning(res2 <- dbSendQuery(con, "SELECT 2")) # nolint: implicit_assignment_linter.
     expect_false(dbIsValid(res1))
     #' The newly opened result set is valid
     expect_true(dbIsValid(res2))

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -85,7 +85,7 @@ spec_result_send_statement <- list(
     #' issuing a second query invalidates an already open result set
     #' and raises a warning.
     query <- ctx$tweaks$create_table_as(other_table_name)
-    expect_warning(res2 <- dbSendStatement(con, query)) # nolint: implicit_assignment_linter.
+    expect_warning(res2 <- dbSendStatement(con, query))
     expect_false(dbIsValid(res1))
     #' The newly opened result set is valid
     expect_true(dbIsValid(res2))

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -57,7 +57,7 @@ spec_result_send_statement <- list(
   send_statement_result_valid = function(ctx, con, table_name) {
     #' @section Specification:
     #' No warnings occur under normal conditions.
-    expect_warning(res <- dbSendStatement(con, trivial_statement(ctx, table_name)), NA)
+    res <- expect_warning(dbSendStatement(con, trivial_statement(ctx, table_name)), NA)
     #' When done, the DBIResult object must be cleared with a call to
     #' [dbClearResult()].
     dbClearResult(res)
@@ -85,7 +85,7 @@ spec_result_send_statement <- list(
     #' issuing a second query invalidates an already open result set
     #' and raises a warning.
     query <- ctx$tweaks$create_table_as(other_table_name)
-    expect_warning(res2 <- dbSendStatement(con, query))
+    res2 <- expect_warning(dbSendStatement(con, query))
     expect_false(dbIsValid(res1))
     #' The newly opened result set is valid
     expect_true(dbIsValid(res2))

--- a/R/spec-result-send-statement.R
+++ b/R/spec-result-send-statement.R
@@ -85,7 +85,7 @@ spec_result_send_statement <- list(
     #' issuing a second query invalidates an already open result set
     #' and raises a warning.
     query <- ctx$tweaks$create_table_as(other_table_name)
-    res2 <- expect_warning(dbSendStatement(con, query))
+    expect_warning(res2 <- dbSendStatement(con, query)) # nolint: implicit_assignment_linter.
     expect_false(dbIsValid(res1))
     #' The newly opened result set is valid
     expect_true(dbIsValid(res2))

--- a/R/spec-transaction-with-transaction.R
+++ b/R/spec-transaction-with-transaction.R
@@ -99,7 +99,7 @@ spec_transaction_with_transaction <- list(
     #' All side effects caused by the code
     expect_false(exists("a", inherits = FALSE))
     #' (such as the creation of new variables)
-    dbWithTransaction(con, a <- 42)
+    dbWithTransaction(con, a <- 42) # nolint: implicit_assignment_linter.
     #' propagate to the calling environment.
     expect_identical(get0("a", inherits = FALSE), 42)
   },


### PR DESCRIPTION
Follow-up on #542: fixes the `implicit_assignment_linter` violations (9 occurrences).

- **No warning expected** (`regexp = NA`, 4 sites): rewritten as `res <- expect_warning(expr, NA)`. `expect_warning()` returns the value of its object when no condition is caught, so the assigned value is unchanged.
- **Warning expected** (4 sites, e.g. `expect_warning(res2 <- dbSendQuery(con, "SELECT 2"))`): the assignment must stay **inside** `expect_warning()`, because when a warning is caught `expect_warning()` returns the *condition*, not the value (see [r-lib/lintr#2267](https://github.com/r-lib/lintr/issues/2267)). Rather than inline `nolint` directives, these are allowlisted via the linter's `except` config in `.lintr.R` (see #550).
- `dbWithTransaction(con, a <- 42)` in `with_transaction_side_effects` deliberately assigns inside the transaction to test that side effects propagate; it keeps a `# nolint` directive (it is not an `expect_warning()` call, so the `except` config does not cover it).

The linter is re-enabled (with the `except`) in #550 once all the code fixes have landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvAeoWDREMgDse3TQgFDNp