### PR TITLE
fix: Specify `stringsAsFactors = FALSE` explicitly in `data.frame()` calls

### DIFF
--- a/R/spec-meta-bind-arrow-stream.R
+++ b/R/spec-meta-bind-arrow-stream.R
@@ -421,7 +421,7 @@ spec_meta_arrow_stream_bind <- list(
     is_null_check <- ctx$tweaks$is_null_check
     for (placeholder_fun in placeholder_funs) {
       bind_values <- structure(
-        data.frame("\U{41A}\U{438}\U{440}\U{438}\U{43B}\U{43B}", "M\U{FC}ller", (`Encoding<-`)("M\xfcller", "latin1"), "\U{6211}\U{662F}\U{8C01}", "ASCII", NA_character_),
+        data.frame("\U{41A}\U{438}\U{440}\U{438}\U{43B}\U{43B}", "M\U{FC}ller", (`Encoding<-`)("M\xfcller", "latin1"), "\U{6211}\U{662F}\U{8C01}", "ASCII", NA_character_, stringsAsFactors = FALSE),
         names = character(6)
       )
       placeholder <- placeholder_fun(6L)
@@ -453,7 +453,7 @@ spec_meta_arrow_stream_bind <- list(
     placeholder_funs <- get_placeholder_funs(ctx)
     is_null_check <- ctx$tweaks$is_null_check
     for (placeholder_fun in placeholder_funs) {
-      bind_values <- structure(data.frame(" ", "\n", "\r", "\b", "'", '"', "[", "]", "\\", NA_character_), names = character(10))
+      bind_values <- structure(data.frame(" ", "\n", "\r", "\b", "'", '"', "[", "]", "\\", NA_character_, stringsAsFactors = FALSE), names = character(10))
       placeholder <- placeholder_fun(10L)
       names(bind_values) <- names(placeholder)
       placeholder_values <- map_chr(bind_values, function(x) DBI::dbQuoteLiteral(con, x[1]))

--- a/R/spec-meta-bind-stream.R
+++ b/R/spec-meta-bind-stream.R
@@ -563,7 +563,7 @@ spec_meta_stream_bind <- list(
     is_null_check <- ctx$tweaks$is_null_check
     for (placeholder_fun in placeholder_funs) {
       bind_values <- structure(
-        data.frame("\U{41A}\U{438}\U{440}\U{438}\U{43B}\U{43B}", "M\U{FC}ller", (`Encoding<-`)("M\xfcller", "latin1"), "\U{6211}\U{662F}\U{8C01}", "ASCII", NA_character_),
+        data.frame("\U{41A}\U{438}\U{440}\U{438}\U{43B}\U{43B}", "M\U{FC}ller", (`Encoding<-`)("M\xfcller", "latin1"), "\U{6211}\U{662F}\U{8C01}", "ASCII", NA_character_, stringsAsFactors = FALSE),
         names = character(6)
       )
       placeholder <- placeholder_fun(6L)
@@ -595,7 +595,7 @@ spec_meta_stream_bind <- list(
     placeholder_funs <- get_placeholder_funs(ctx)
     is_null_check <- ctx$tweaks$is_null_check
     for (placeholder_fun in placeholder_funs) {
-      bind_values <- structure(data.frame(" ", "\n", "\r", "\b", "'", '"', "[", "]", "\\", NA_character_), names = character(10))
+      bind_values <- structure(data.frame(" ", "\n", "\r", "\b", "'", '"', "[", "]", "\\", NA_character_, stringsAsFactors = FALSE), names = character(10))
       placeholder <- placeholder_fun(10L)
       names(bind_values) <- names(placeholder)
       placeholder_values <- map_chr(bind_values, function(x) DBI::dbQuoteLiteral(con, x[1]))

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -697,10 +697,10 @@ spec_sql_write_table <- list(
     #' The `field.types` argument must be a named character vector with at most
     #' one entry for each column.
     #' It indicates the SQL data type to be used for a new column.
-    tbl_in <- data.frame(a = numeric(), b = character())
+    tbl_in <- data.frame(a = numeric(), b = character(), stringsAsFactors = FALSE)
     #' If a column is missed from `field.types`, the type is inferred
     #' from the input data with [dbDataType()].
-    tbl_exp <- data.frame(a = integer(), b = character())
+    tbl_exp <- data.frame(a = integer(), b = character(), stringsAsFactors = FALSE)
     test_table_roundtrip(
       con, tbl_in, tbl_exp,
       field.types = c(a = "INTEGER")


### PR DESCRIPTION
Follow-up on #542: fixes the `strings_as_factors_linter` violations (6 occurrences).

The package declares `R (>= 3.2.0)` in `DESCRIPTION`. Before R 4.0, `data.frame()` defaulted to `stringsAsFactors = TRUE`, so these test fixtures in `spec-meta-bind-arrow-stream.R`, `spec-meta-bind-stream.R`, and `spec-sql-write-table.R` behaved differently on older R. Passing `stringsAsFactors = FALSE` explicitly makes them stable across R versions and satisfies the linter.

The linter itself is re-enabled in a separate final PR that updates `.lintr.R` once all the code fixes have landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvAeoWDREMgDse3TQgFDNp

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvAeoWDREMgDse3TQgFDNp)_