### PR TITLE
fix: Order arguments without defaults before those with defaults

### DIFF
--- a/R/spec-meta-bind-.R
+++ b/R/spec-meta-bind-.R
@@ -2,10 +2,10 @@
 
 test_select_bind_expr <- function(
   bind_values,
-  ctx = stop("ctx is available during run time only", call. = FALSE),
   ...,
   arrow,
   bind,
+  ctx = stop("ctx is available during run time only", call. = FALSE),
   query = TRUE,
   skip_fun = NULL,
   dbitest_version = NULL,

--- a/R/spec-result-roundtrip.R
+++ b/R/spec-result-roundtrip.R
@@ -267,8 +267,8 @@ test_select_with_null <- function(...) {
 test_select <- function(
   con,
   ...,
-  .add_null = "none",
   .ctx,
+  .add_null = "none",
   .envir = parent.frame()
 ) {
 

--- a/R/spec-result.R
+++ b/R/spec-result.R
@@ -15,7 +15,7 @@ spec_result <- c(
 
 # Helpers -----------------------------------------------------------------
 
-sql_union <- function(..., .order_by = NULL, .ctx) {
+sql_union <- function(..., .ctx, .order_by = NULL) {
   queries <- c(...)
   if (length(queries) == 1) {
     query <- queries


### PR DESCRIPTION
Follow-up on #542: fixes the `function_argument_linter` violations (4 occurrences).

Reorders keyword-only arguments in `test_select_bind_expr()`, `test_select()`, and `sql_union()` so that arguments without defaults come before those with defaults:

- `test_select_bind_expr()`: `ctx = stop(...)` moved after `arrow`/`bind`.
- `test_select()`: `.ctx` moved before `.add_null = "none"`.
- `sql_union()`: `.ctx` moved before `.order_by = NULL`.

All affected arguments follow `...`, so they are keyword-only and every call site already passes them by name — no caller changes are needed.

**Note:** this branch is based on #543 (`condition_call`), because both edit the `ctx = stop(...)` line in `test_select_bind_expr()`. Stacking them this way lets the two PRs merge in either order without a conflict; #543's two-line change therefore also appears in this diff. Merge #543 first for the cleanest history (this PR then reduces to just the reordering), or merge this one alone — both are conflict-free.

The linter itself is re-enabled in a separate final PR that updates `.lintr.R` once all the code fixes have landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvAeoWDREMgDse3TQgFDNp