### PR TITLE
fix: Mark intentional empty `pairlist2()` args as `nolint`

### DIFF
--- a/tests/testthat/helper-dev.R
+++ b/tests/testthat/helper-dev.R
@@ -47,7 +47,7 @@ inline_meta_tests <- function(arrow, bind, path) {
   test_exprs_flat <- map(test_exprs, flatten_braces)
 
   env <- environment(inline_meta_tests)
-  args <- pairlist2(ctx = , con = )
+  args <- pairlist2(ctx = , con = ) # nolint: missing_argument_linter.
 
   test_funs <- map(test_exprs_flat, ~ if (!is.null(.x)) {
     new_function(args, .x, env)


### PR DESCRIPTION
Follow-up on #542: fixes the `missing_argument_linter` violations (2 occurrences, one line).

`pairlist2(ctx = , con = )` in `helper-dev.R` intentionally builds a pairlist of empty (missing) arguments, later used as the formals of a generated function. This is a valid `rlang` idiom, so the linter warning is a false positive; it is suppressed with an inline `# nolint: missing_argument_linter.` directive rather than by changing the code.

The linter itself is re-enabled in a separate final PR that updates `.lintr.R` once all the code fixes have landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvAeoWDREMgDse3TQgFDNp

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvAeoWDREMgDse3TQgFDNp)_