### PR TITLE
ci: Re-enable linters fixed after #542

### DIFF
--- a/.lintr.R
+++ b/.lintr.R
@@ -1,28 +1,26 @@
 linters <- modify_defaults(
   all_linters(),
   absolute_path_linter = NULL,
-  commented_code_linter = NULL,
-  condition_call_linter = NULL,
   cyclocomp_linter = NULL,
   expect_identical_linter = NULL,
   expect_shape_linter = NULL, # 94 occurrences, to fix
-  function_argument_linter = NULL,
   if_switch_linter = NULL, # false positive: r-lib/lintr#2835
-  implicit_assignment_linter = NULL,
+  # expect_warning(x <- ...) is idiomatic, see r-lib/lintr#2267
+  implicit_assignment_linter = implicit_assignment_linter(
+    except = c("bquote", "expression", "expr", "quo", "quos", "quote", "expect_warning")
+  ),
   implicit_integer_linter = NULL,
   keyword_quote_linter = NULL,
   line_length_linter = NULL,
-  missing_argument_linter = NULL,
   namespace_linter = NULL,
   nonportable_path_linter = NULL,
-  nzchar_linter = NULL,
+  nzchar_linter = NULL, # x != "" reads better than nzchar(x)
   object_length_linter = NULL,
   object_name_linter = NULL,
   object_overwrite_linter = NULL,
   object_usage_linter = NULL,
   one_call_pipe_linter = NULL,
   pipe_consistency_linter = NULL, # 51 occurrences, to fix
-  strings_as_factors_linter = NULL,
   todo_comment_linter = NULL,
   undesirable_function_linter = NULL,
   unused_import_linter = NULL


### PR DESCRIPTION
Follow-up on #542: re-enables the linters whose violations have been fixed, by editing `.lintr.R`.

Re-enabled here:

| Linter | Occurrences fixed | Code-fix PR | Status |
|---|---|---|---|
| `condition_call_linter` | 2 | #543 | merged |
| `strings_as_factors_linter` | 6 | #546 | merged |
| `missing_argument_linter` | 2 | #548 | merged |
| `implicit_assignment_linter` | 9 | #545 | open |
| `function_argument_linter` | 4 | #547 | open |
| `commented_code_linter` | 4 | #549 | open |

`implicit_assignment_linter` is enabled **with an `except`** that allowlists `expect_warning(x <- ...)` — an idiomatic pattern where the assignment must stay inside the call (`expect_warning()` returns the condition, not the value, when a warning is expected). See [r-lib/lintr#2267](https://github.com/r-lib/lintr/issues/2267). This replaces the inline `nolint` directives that #545 previously used for those sites.

Kept disabled on purpose:

- `nzchar_linter` — `x != ""` reads better than `nzchar(x)`; kept off with a comment (#544 closed).
- `cyclocomp_linter` (12), `expect_shape_linter` (94), `pipe_consistency_linter` (51) — above the 10-occurrence threshold.
- `todo_comment_linter` (7 genuine `FIXME`/`TODO`s) and `object_length_linter` (renames public `spec_*` API) — skipped as destructive.

**Merge order:** merge after the three open code-fix PRs land; until then the lint workflow flags the not-yet-fixed code. Verified locally with dev `lintr` (r-universe build) that the full end state — current `main` + #545 + #547 + #549 + this `.lintr.R` — is lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvAeoWDREMgDse3TQgFDNp